### PR TITLE
Feature: move lib/util to lib/os/process

### DIFF
--- a/lib/os/process/atexit.go
+++ b/lib/os/process/atexit.go
@@ -13,9 +13,10 @@ var atExit struct {
 // AtExit registers a function to be called when `process.Exit` from this package is called.
 //
 // Subsequent calls to AtExit do not overwrite previous calls,
-// and registered functions are executed in stack order, in order to mimic the behavior of `defer`.
+// and registered functions are executed in stack order,
+// in order to mimic the behavior of `defer`.
 //
-// Since AtExit does not hoot into the standard-library `os.Exit`,
+// Since AtExit does not hook into the standard-library `os.Exit`,
 // you must avoid using any function that calls `os.Exit` (most often `Fatal`-type logging methods).
 func AtExit(f func()) {
 	atExit.Lock()
@@ -35,7 +36,8 @@ func runExitFuncs() {
 
 // Exit causes the current program to exit with the given status code.
 //
-// Exit runs the sequence of functions established by `AtExit` and then calls os.Exit with the given status.
+// Exit runs the sequence of functions established by `process.AtExit`,
+// and then calls `os.Exit` with the given status.
 func Exit(status int) {
 	runExitFuncs()
 

--- a/lib/os/process/atexit.go
+++ b/lib/os/process/atexit.go
@@ -1,0 +1,43 @@
+package process
+
+import (
+	"os"
+	"sync"
+)
+
+var atExit struct {
+	sync.Mutex
+	f []func()
+}
+
+// AtExit registers a function to be called when `process.Exit` from this package is called.
+//
+// Subsequent calls to AtExit do not overwrite previous calls,
+// and registered functions are executed in stack order, in order to mimic the behavior of `defer`.
+//
+// Since AtExit does not hoot into the standard-library `os.Exit`,
+// you must avoid using any function that calls `os.Exit` (most often `Fatal`-type logging methods).
+func AtExit(f func()) {
+	atExit.Lock()
+	defer atExit.Unlock()
+
+	atExit.f = append(atExit.f, f)
+}
+
+func runExitFuncs() {
+	atExit.Lock()
+	// intentionally do not unlock.
+
+	for i := len(atExit.f) - 1; i >= 0; i-- {
+		atExit.f[i]()
+	}
+}
+
+// Exit causes the current program to exit with the given status code.
+//
+// Exit runs the sequence of functions established by `AtExit` and then calls os.Exit with the given status.
+func Exit(status int) {
+	runExitFuncs()
+
+	os.Exit(status)
+}

--- a/lib/os/process/context.go
+++ b/lib/os/process/context.go
@@ -56,6 +56,10 @@ func HangupChannel() <-chan struct{} {
 	return sigHandler.hup.get()
 }
 
+// signalHandler starts a long-lived goroutine, which will run in the background until the process ends.
+// It returns a `context.Context` that will be canceled in the event of a signal being received.
+// It will then continue to listen for more signals,
+// If it receives three signals, then we presume that we are not shutting down properly, and panic with all stacktraces.
 func signalHandler(parent context.Context) context.Context {
 	ctx, cancel := context.WithCancel(parent)
 

--- a/lib/os/process/context.go
+++ b/lib/os/process/context.go
@@ -1,0 +1,155 @@
+package process
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime/debug"
+	"sync"
+	"syscall"
+)
+
+type signaler struct {
+	sync.Once
+	ch chan struct{}
+}
+
+// get returns a receive-only copy of the underlying channel for the signaler.
+// If the channel does not exist, it will be allocated.
+func (h *signaler) get() <-chan struct{} {
+	h.Do(func() {
+		h.ch = make(chan struct{})
+	})
+
+	return h.ch
+}
+
+// trySend does the job of trying to send the optional notification to the underlying channel.
+// It will return true if it successfully sends a notification.
+func (h *signaler) trySend() bool {
+	select {
+	case h.ch <- struct{}{}: // A send on a `nil` channel always blocks.
+		return true
+	default:
+	}
+
+	return false
+}
+
+var sigHandler struct {
+	sync.Once
+	ctx context.Context
+	ch  chan os.Signal
+
+	hup signaler
+}
+
+// HangupChannel provides a receiver channel that will notify the caller of when a SIGHUP signal has been received.
+// This signal is often used by daemons to be notified of a request to reload configuration data.
+//
+// Note, that if too many SIGHUPs arrive at once, and the signal handler would block trying to send this notification,
+// then it will treat the signal the same as any other terminating signals.
+func HangupChannel() <-chan struct{} {
+	return sigHandler.hup.get()
+}
+
+func signalHandler(parent context.Context) context.Context {
+	ctx, cancel := context.WithCancel(parent)
+
+	go func() {
+		killChan := make(chan struct{}, 3)
+
+		signal.Notify(sigHandler.ch, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
+
+		for sig := range sigHandler.ch {
+			fmt.Fprintln(os.Stderr, "received signal:", sig)
+
+			switch sig {
+			case syscall.SIGQUIT:
+				debug.SetTraceback("all")
+				panic("SIGQUIT")
+
+			case syscall.SIGHUP:
+				if sigHandler.hup.trySend() {
+					continue
+				}
+			}
+
+			cancel()
+
+			select {
+			case killChan <- struct{}{}: // killChan is not full, keep handling signals.
+			default:
+				// We have gotten three signals and we are still kicking,
+				// panic and dump all stack traces.
+				debug.SetTraceback("all")
+				panic("not responding to signals")
+			}
+		}
+
+		debug.SetTraceback("all")
+		panic("signal handler channel unexpectedly closed")
+	}()
+
+	return ctx
+}
+
+// Context returns a process-level `context.Context`
+// that is cancelled when the program receives any termination signals.
+//
+// A process should start a graceful shutdown process once this context is cancelled.
+//
+// This context should not be used as a parent to any requests,
+// otherwise those requests will also be cancelled
+// instead of being allowed to complete their work.
+func Context() context.Context {
+	sigHandler.Do(func() {
+		sigHandler.ch = make(chan os.Signal, 1)
+		sigHandler.ctx = signalHandler(context.Background())
+	})
+
+	return sigHandler.ctx
+}
+
+// Shutdown starts any graceful shutdown processes waiting for `process.Context()` to be cancelled.
+//
+// Shutdown works by injecting a `syscall.SIGTERM` directly to the signal handler,
+// which will cancel the `process.Context()` the same as a real SIGTERM.
+//
+// Shutdown returns an error if it is unable to send the signal.
+//
+// Shutdown does not wait for anything to finish before returning.
+func Shutdown() error {
+	select {
+	case sigHandler.ch <- syscall.SIGTERM:
+		return nil
+	default:
+	}
+
+	return errors.New("could not send signal")
+}
+
+// Quit ends the program as soon as possible, dumping a stacktrace of all goroutines.
+//
+// Quit works by injecting a `syscall.SIGQUIT` directly to the signal handler,
+// which will cause a panic, and stacktrace of all goroutines the same as a real SIGQUIT.
+//
+// If Quit cannot inject the signal,
+// it will setup an unrecoverable panic to occur.
+//
+// In all cases, Quit will not return.
+func Quit() {
+	select {
+	case sigHandler.ch <- syscall.SIGQUIT:
+	default:
+		// We start up a separate goroutine for this to ensure that no `recover()` can block this panic.
+		go func() {
+			debug.SetTraceback("all")
+			panic("process was force quit")
+		}()
+	}
+
+	select {} // Block forever so we never return.
+}

--- a/lib/os/process/context.go
+++ b/lib/os/process/context.go
@@ -58,10 +58,10 @@ func HangupChannel() <-chan struct{} {
 func signalHandler(parent context.Context) context.Context {
 	ctx, cancel := context.WithCancel(parent)
 
+	signal.Notify(sigHandler.ch, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
+
 	go func() {
 		killChan := make(chan struct{}, 3)
-
-		signal.Notify(sigHandler.ch, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
 
 		for sig := range sigHandler.ch {
 			fmt.Fprintln(os.Stderr, "received signal:", sig)

--- a/lib/os/process/init.go
+++ b/lib/os/process/init.go
@@ -16,14 +16,16 @@ var (
 	})
 )
 
-// Init is initialization code that provides basic functionality for command-line programs.
-// It parses flags, sets up AtExit, and will start profiling if the appropriate flag is set.
-// It takes as parameters version information,
-// the first argument being the command's identifying string,
-// and then a series of numbers which indicate the various version points.
-// It returns the context.Context from util.Context(),
-// and a function that should be defer'ed in your main() function,
-// which will take care of executing the queued AtExitFuncs even in a panic() situation.
+// Init is initialization code that provides basic functionality for processes.
+//
+// Init takes as parameters version information, identifying the Command Name, Semver, and a Buildstamp.
+// The Buildstamp could be just a timestamp, or could include a commit hash or other reference.
+//
+// Init parses flags, sets up AtExit, and will start profiling if the appropriate flag is set.
+//
+// It returns the `context.Context` from `process.Context()`,
+// and a function that `main` should `defer`,
+// which will take care of executing the queued AtExit functions.
 func Init(cmdname, semver, buildstamp string) (context.Context, func()) {
 	buildVersion(cmdname, semver, buildstamp)
 

--- a/lib/os/process/init.go
+++ b/lib/os/process/init.go
@@ -1,0 +1,43 @@
+package process
+
+import (
+	"context"
+	"fmt"
+
+	flag "github.com/puellanivis/breton/lib/gnuflag"
+)
+
+// Go libraries should not set flags themselves, these are an exception.
+var (
+	profile = flag.String("profile", "write cpu profile to `filename`.prof and heap profile to filename.mprof")
+	_       = flag.BoolFunc("version", "display version information", func() {
+		fmt.Println(Version())
+		Exit(0)
+	})
+)
+
+// Init is initialization code that provides basic functionality for command-line programs.
+// It parses flags, sets up AtExit, and will start profiling if the appropriate flag is set.
+// It takes as parameters version information,
+// the first argument being the command's identifying string,
+// and then a series of numbers which indicate the various version points.
+// It returns the context.Context from util.Context(),
+// and a function that should be defer'ed in your main() function,
+// which will take care of executing the queued AtExitFuncs even in a panic() situation.
+func Init(cmdname, semver, buildstamp string) (context.Context, func()) {
+	buildVersion(cmdname, semver, buildstamp)
+
+	flag.Parse()
+
+	if *profile != "" {
+		setupProfiling()
+	}
+
+	return Context(), func() {
+		runExitFuncs()
+
+		if r := recover(); r != nil {
+			panic(r)
+		}
+	}
+}

--- a/lib/os/process/profile.go
+++ b/lib/os/process/profile.go
@@ -1,0 +1,28 @@
+package process
+
+import (
+	"os"
+	"runtime/pprof"
+)
+
+func setupProfiling() {
+	cpuf, err := os.Create(*profile + ".prof")
+	if err != nil {
+		panic(err)
+	}
+
+	memf, err := os.Create(*profile + ".mprof")
+	if err != nil {
+		panic(err)
+	}
+
+	_ = pprof.StartCPUProfile(cpuf)
+
+	AtExit(func() {
+		pprof.StopCPUProfile()
+		cpuf.Close()
+
+		_ = pprof.WriteHeapProfile(memf)
+		memf.Close()
+	})
+}

--- a/lib/os/process/version.go
+++ b/lib/os/process/version.go
@@ -1,10 +1,5 @@
 package process
 
-import (
-	"fmt"
-	"strings"
-)
-
 var versionString string
 
 // Version returns the version information populated during util.Init().
@@ -13,7 +8,9 @@ func Version() string {
 }
 
 func buildVersion(cmdname, semver, buildstamp string) {
-	semver = strings.TrimPrefix(semver, "v")
+	versionString = cmdname + " " + semver
 
-	versionString = fmt.Sprintf("%s v%s-%s", cmdname, semver, buildstamp)
+	if buildstamp != "" {
+		versionString = versionString + "-" + buildstamp
+	}
 }

--- a/lib/os/process/version.go
+++ b/lib/os/process/version.go
@@ -1,0 +1,19 @@
+package process
+
+import (
+	"fmt"
+	"strings"
+)
+
+var versionString string
+
+// Version returns the version information populated during util.Init().
+func Version() string {
+	return versionString
+}
+
+func buildVersion(cmdname, semver, buildstamp string) {
+	semver = strings.TrimPrefix(semver, "v")
+
+	versionString = fmt.Sprintf("%s v%s-%s", cmdname, semver, buildstamp)
+}

--- a/lib/util/atexit.go
+++ b/lib/util/atexit.go
@@ -2,48 +2,21 @@ package util
 
 import (
 	"context"
-	"os"
-	"runtime/pprof"
-	"sync"
 
-	flag "github.com/puellanivis/breton/lib/gnuflag"
-)
-
-var (
-	// Go libraries should not set flags themselves, this is an exception.
-	profile = flag.String("profile", "write cpu profile to `filename`.prof and heap profile to filename.mprof")
+	"github.com/puellanivis/breton/lib/os/process"
 )
 
 // AtExitFunc is a function type that can be deferred for execution at the time of the program's exit. (Will NOT work if you call os.Exit(), you must call util.Exit())
 type AtExitFunc func()
 
-var atExit struct {
-	sync.Mutex
-	f []AtExitFunc
-}
-
 // AtExit queues the given AtExitFuncs to be executed at program exit time.
 func AtExit(f AtExitFunc) {
-	atExit.Lock()
-	defer atExit.Unlock()
-
-	atExit.f = append([]AtExitFunc{f}, atExit.f...)
-}
-
-func runExitFuncs() {
-	atExit.Lock()
-	defer atExit.Unlock() // just in case
-
-	for _, f := range atExit.f {
-		f()
-	}
+	process.AtExit(f)
 }
 
 // Exit runs the queued AtExitFuncs and then calls os.Exit with the given status.
 func Exit(status int) {
-	runExitFuncs()
-
-	os.Exit(status)
+	process.Exit(status)
 }
 
 // Init is initialization code that provides basic functionality for command-line programs.
@@ -55,37 +28,5 @@ func Exit(status int) {
 // and a function that should be defer'ed in your main() function,
 // which will take care of executing the queued AtExitFuncs even in a panic() situation.
 func Init(cmdname string, versions ...uint) (context.Context, func()) {
-	initVersion(cmdname, versions...)
-
-	flag.Parse()
-
-	if *profile != "" {
-		cpuf, err := os.Create(*profile + ".prof")
-		if err != nil {
-			panic(err)
-		}
-
-		memf, err := os.Create(*profile + ".mprof")
-		if err != nil {
-			panic(err)
-		}
-
-		_ = pprof.StartCPUProfile(cpuf)
-
-		AtExit(func() {
-			pprof.StopCPUProfile()
-			cpuf.Close()
-
-			_ = pprof.WriteHeapProfile(memf)
-			memf.Close()
-		})
-	}
-
-	return utilCtx, func() {
-		runExitFuncs()
-
-		if r := recover(); r != nil {
-			panic(r)
-		}
-	}
+	return process.Init(cmdname, buildSemver(versions), BUILD)
 }

--- a/lib/util/context.go
+++ b/lib/util/context.go
@@ -2,21 +2,8 @@ package util
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"os/signal"
-	"runtime/debug"
-	"sync"
-	"syscall"
-	"time"
-)
 
-var (
-	utilCtx context.Context
-	sigchan = make(chan os.Signal)
-
-	hupMutex sync.Mutex
-	hupchan  chan struct{}
+	"github.com/puellanivis/breton/lib/os/process"
 )
 
 // HangupChannel provides a receiver channel that will notify the caller of when a SIGHUP signal has been received.
@@ -25,99 +12,17 @@ var (
 // Note, that if too many SIGHUPs arrive at once, and the signal handler would block trying to send this notification,
 // then it will treat the signal the same as any other terminating signals.
 func HangupChannel() <-chan struct{} {
-	hupMutex.Lock()
-	defer hupMutex.Unlock()
-
-	if hupchan == nil {
-		hupchan = make(chan struct{})
-	}
-
-	return hupchan
-}
-
-// sendHup does the job of locking the hupMutex and trying to send the HUP notification.
-// It will return true if it successfully sends the notification.
-func sendHup() bool {
-	hupMutex.Lock()
-	defer hupMutex.Unlock()
-
-	if hupchan == nil {
-		return false
-	}
-
-	select {
-	case hupchan <- struct{}{}:
-		return true
-	default:
-		fmt.Fprintln(os.Stderr, "too many hangungs: terminating")
-	}
-
-	return false
-}
-
-func init() {
-	var cancel context.CancelFunc
-	utilCtx, cancel = context.WithCancel(context.Background())
-
-	signal.Notify(sigchan, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
-
-	go func() {
-		killchan := make(chan struct{}, 3)
-
-		for sig := range sigchan {
-			fmt.Fprintln(os.Stderr, "received signal:", sig)
-
-			switch sig {
-			case syscall.SIGHUP:
-				if sendHup() {
-					continue
-				}
-			}
-
-			cancel()
-
-			select {
-			case killchan <- struct{}{}:
-				go func() {
-					<-time.After(1 * time.Second)
-
-					select {
-					case <-killchan:
-					default:
-					}
-				}()
-
-			default:
-				debug.SetTraceback("all")
-				panic("not responding to signals")
-			}
-		}
-
-		debug.SetTraceback("all")
-		panic("process was force quit")
-	}()
+	return process.HangupChannel()
 }
 
 // Context returns a context.Context that will cancel if the program receives any signal that a program may want to cleanup after.
 func Context() context.Context {
-	return utilCtx
+	return process.Context()
 }
 
 // Quit causes a closure of the signal channel, which causes the signal handler
 // to cancel the util.Context() context, leading to a (hopefully) graceful-ish
 // shutdown of the program.
 func Quit() {
-	select {
-	case _, closed := <-sigchan:
-		if closed {
-			return
-		}
-	default:
-	}
-
-	// by closing this channel, the for range signchan above ends,
-	// which means, we essentially make a kill signal, but
-	// without actually causing a signal.
-	// (Important for Windows, which doesn’t have signaling.)
-	close(sigchan)
+	process.Quit()
 }

--- a/lib/util/version.go
+++ b/lib/util/version.go
@@ -1,22 +1,11 @@
 package util
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
-	flag "github.com/puellanivis/breton/lib/gnuflag"
+	"github.com/puellanivis/breton/lib/os/process"
 )
-
-var (
-	// Go libraries should not set flags themselves, this is an exception.
-	_ = flag.BoolFunc("version", "display version information", func() {
-		fmt.Println(versionString)
-		Exit(0)
-	})
-)
-
-var versionString string
 
 // BUILD is a value that can be set by the go build command-line
 // in order to provide additional context information for the build,
@@ -25,10 +14,10 @@ var BUILD = "adhoc"
 
 // Version returns the version information populated during util.Init().
 func Version() string {
-	return versionString
+	return process.Version()
 }
 
-func initVersion(cmdname string, versions ...uint) {
+func buildSemver(versions []uint) string {
 	var tmp []string
 
 	if len(versions) < 1 {
@@ -39,5 +28,5 @@ func initVersion(cmdname string, versions ...uint) {
 		tmp = append(tmp, strconv.FormatUint(uint64(ver), 10))
 	}
 
-	versionString = fmt.Sprintf("%s v%s-%s", cmdname, strings.Join(tmp, "."), BUILD)
+	return "v" + strings.Join(tmp, ".")
 }


### PR DESCRIPTION
Rework the `lib/util` library to remove the various process functionality into a meaningful package name.

Also, refactor and redesign the API. It should largely be a largely compatible API change.