### PR TITLE
Go113 fixes

### DIFF
--- a/lib/gnuflag/slices.go
+++ b/lib/gnuflag/slices.go
@@ -6,19 +6,6 @@ import (
 	"strings"
 )
 
-// arrayWrap is used to make array-based flags that will run the setterFunc on every element of a split on ","
-func arrayWrap(fn setterFunc) setterFunc {
-	return func(s string) error {
-		for _, v := range strings.Split(s, ",") {
-			if err := fn(v); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}
-}
-
 type sliceValue struct {
 	value interface{} // this must be a pointer to the slice!
 	fn    func(s string) error


### PR DESCRIPTION
Go 1.13 has tighter escape mechanics built in, and called out a number of rules about what kind of guarantees are allowed to be made on the `unsafe.Pointer` type. Most importantly, one needs to not hold the `unsafe.Pointer` in a temporary value, but rather one must immediately do type conversion at the time of the cast to `unsafe.Pointer`. This is to preserve the semantics of pointers for the garbage collector.

So, we implement that here.