### PR TITLE
URL RFC notes that ports can only be numeric

### DIFF
--- a/lib/files/path_test.go
+++ b/lib/files/path_test.go
@@ -52,7 +52,7 @@ func TestPathPOSIX(t *testing.T) {
 }
 
 func TestPathURL(t *testing.T) {
-	p, err := url.Parse("scheme://username:password@hostname:port/path/?query#fragment")
+	p, err := url.Parse("scheme://username:password@hostname:12345/path/?query#fragment")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func TestPathURL(t *testing.T) {
 	ctx := WithRootURL(context.Background(), p)
 
 	filename := makePath("filename")
-	if path := resolveFilename(ctx, filename); path.String() != "scheme://username:password@hostname:port/path/filename" {
+	if path := resolveFilename(ctx, filename); path.String() != "scheme://username:password@hostname:12345/path/filename" {
 		t.Errorf("resolveFilename with %q and %q gave %#v instead", filename, p, path)
 	}
 

--- a/lib/gnuflag/struct_test.go
+++ b/lib/gnuflag/struct_test.go
@@ -111,7 +111,7 @@ func TestSpecialValues(t *testing.T) {
 	}
 
 	Flags.AUint8Alias = 42
-	MyURL, err := url.Parse("scheme://hostname:port/path")
+	MyURL, err := url.Parse("scheme://hostname:12345/path")
 	if err != nil {
 		t.Fatal("unexpected error parsing url:", err)
 	}
@@ -148,7 +148,7 @@ func TestSpecialValues(t *testing.T) {
 	}
 
 	checkFlag("a-uint8-alias", "42", "AUint8Alias `uint8`", Flags.AUint8Alias, byte(42))
-	checkFlag("my-url", "scheme://hostname:port/path", "MyURL `*url.URL`", Flags.MyURL, MyURL)
+	checkFlag("my-url", "scheme://hostname:12345/path", "MyURL `*url.URL`", Flags.MyURL, MyURL)
 
 	for k := range fs.formal {
 		if !checkedKeys[k] {


### PR DESCRIPTION
https://tools.ietf.org/html/rfc3986?#section-3.2.3

Go at version 1.12.8 started enforcing this.