### PR TITLE
Masher updates

### DIFF
--- a/masher/mash.sh
+++ b/masher/mash.sh
@@ -68,6 +68,11 @@ while [[ "$#" -gt 0 ]]; do
 	shift
 done
 
+if [[ -d ./vendor ]]; then
+	export GOFLAGS="-mod=vendor"
+	VENDOR="true"
+fi
+
 if [[ $ESCAPE == "true" ]]; then
 	exec /bin/bash "$@"
 	exit 1
@@ -162,7 +167,7 @@ if [[ $NOCOMPILE != "true" ]]; then
 		fi
 
 		dep ensure $DEP_UP
-	else
+	elif [[ $VENDOR != "true" ]]; then
 		go get -v -d || exit 1
 	fi
 fi

--- a/masher/mash.sh
+++ b/masher/mash.sh
@@ -14,6 +14,9 @@ while [[ "$#" -gt 0 ]]; do
 		--id=*)
 			ID="$val"
 		;;
+		--private=*)
+			export GOPRIVATE="$val"
+		;;
 
 		--linux)
 			LINUX="true"

--- a/masher/mash.sh
+++ b/masher/mash.sh
@@ -161,7 +161,7 @@ if [[ $PACKAGE != "main" ]]; then
 	exit 0
 fi
 
-if [[ $NOCOMPILE != "true" ]]; then
+if [[ $VENDOR != "true" && $NOCOMPILE != "true" ]]; then
 	echo getting dependencies...
 	if [[ -r Gopkg.toml ]]; then
 		DEP_UP=""
@@ -170,7 +170,7 @@ if [[ $NOCOMPILE != "true" ]]; then
 		fi
 
 		dep ensure $DEP_UP
-	elif [[ $VENDOR != "true" ]]; then
+	else
 		go get -v -d || exit 1
 	fi
 fi

--- a/masher/mash.sh
+++ b/masher/mash.sh
@@ -8,6 +8,9 @@ while [[ "$#" -gt 0 ]]; do
 		--cache=*)
 			export GOCACHE="$val"
 		;;
+		--buildver=*)
+			VERSION="$val"
+		;;
 		--timestamp=*)
 			TIMESTAMP="$val"
 		;;
@@ -189,6 +192,9 @@ PROJECT="${PWD##*/}"
 if [[ -n $BUILDSTAMP ]]; then
 	DEPS=$( go list -f "{{.Deps}}" | grep -c -e "\<lib/util\>" )
 	LDFLAGS="-ldflags=-X main.VersionBuild=$BUILDSTAMP -X main.Buildstamp=$BUILDSTAMP"
+	if [[ $VERSION != "" ]]; then
+		LDFLAGS="$LDFLAGS -X main.Version=$VERSION"
+	fi
 	if [[ $DEPS -ne 0 ]]; then
 		LDFLAGS="$LDFLAGS -X github.com/puellanivis/breton/lib/util.BUILD=$BUILDSTAMP"
 	fi

--- a/masher/mash.sh
+++ b/masher/mash.sh
@@ -180,9 +180,9 @@ fi
 PROJECT="${PWD##*/}"
 if [[ -n $BUILDSTAMP ]]; then
 	DEPS=$( go list -f "{{.Deps}}" | grep -c -e "\<lib/util\>" )
-	GOFLAGS="-ldflags=-X main.VersionBuild=$BUILDSTAMP -X main.Buildstamp=$BUILDSTAMP"
+	LDFLAGS="-ldflags=-X main.VersionBuild=$BUILDSTAMP -X main.Buildstamp=$BUILDSTAMP"
 	if [[ $DEPS -ne 0 ]]; then
-		GOFLAGS="$GOFLAGS -X github.com/puellanivis/breton/lib/util.BUILD=$BUILDSTAMP"
+		LDFLAGS="$LDFLAGS -X github.com/puellanivis/breton/lib/util.BUILD=$BUILDSTAMP"
 	fi
 fi
 
@@ -196,7 +196,7 @@ if [[ $LINUX == "true" ]]; then
 	OUT="bin/linux.x86_64"
 	echo Compiling ${OUT}/${PROJECT}
 	[ -d "$OUT" ] || mkdir -p $OUT || exit 1
-	GOOS=linux GOARCH=amd64 go build -o "${OUT}/${PROJECT}" "${GOFLAGS}" || exit 1
+	GOOS=linux GOARCH=amd64 go build -o "${OUT}/${PROJECT}" "${LDFLAGS}" || exit 1
 
 	[[ "$DEB" != "false" ]] && DEB="true"
 fi
@@ -205,14 +205,14 @@ if [[ $DARWIN == "true" ]]; then
 	OUT="bin/darwin.x86_64"
 	echo Compiling ${OUT}/${PROJECT}
 	[ -d "$OUT" ] || mkdir -p $OUT || exit 1
-	GOOS=darwin GOARCH=amd64 go build -o "${OUT}/${PROJECT}" "${GOFLAGS}" || exit 1
+	GOOS=darwin GOARCH=amd64 go build -o "${OUT}/${PROJECT}" "${LDFLAGS}" || exit 1
 fi
 
 if [[ $WINDOWS == "true" ]]; then
 	OUT="bin/windows.x86_64"
 	echo Compiling ${OUT}/${PROJECT}.exe
 	[ -d "$OUT" ] || mkdir -p $OUT || exit 1
-	GOOS=windows GOARCH=amd64 go build -o "${OUT}/${PROJECT}.exe" "${GOFLAGS}" || exit 1
+	GOOS=windows GOARCH=amd64 go build -o "${OUT}/${PROJECT}.exe" "${LDFLAGS}" || exit 1
 fi
 
 if [[ ( $DEB == "true" ) && ( -r debian/control ) && ( -x bin/linux.x86_64/${PROJECT} ) ]]; then

--- a/masher/mash.sh
+++ b/masher/mash.sh
@@ -9,7 +9,7 @@ while [[ "$#" -gt 0 ]]; do
 			export GOCACHE="$val"
 		;;
 		--buildver=*)
-			VERSION="$val"
+			BUILDVER="$val"
 		;;
 		--timestamp=*)
 			TIMESTAMP="$val"
@@ -192,8 +192,8 @@ PROJECT="${PWD##*/}"
 if [[ -n $BUILDSTAMP ]]; then
 	DEPS=$( go list -f "{{.Deps}}" | grep -c -e "\<lib/util\>" )
 	LDFLAGS="-ldflags=-X main.VersionBuild=$BUILDSTAMP -X main.Buildstamp=$BUILDSTAMP"
-	if [[ $VERSION != "" ]]; then
-		LDFLAGS="$LDFLAGS -X main.Version=$VERSION"
+	if [[ $BUILDVER != "" ]]; then
+		LDFLAGS="$LDFLAGS -X main.Version=$BUILDVER"
 	fi
 	if [[ $DEPS -ne 0 ]]; then
 		LDFLAGS="$LDFLAGS -X github.com/puellanivis/breton/lib/util.BUILD=$BUILDSTAMP"

--- a/masher/masher
+++ b/masher/masher
@@ -169,6 +169,7 @@ if [[ $? -eq 0 ]]; then
 		HASHID=$(git rev-parse --short HEAD)
 		HEAD=$(git symbolic-ref HEAD 2>> /dev/null || git rev-parse HEAD)
 		BRANCH=$(basename ${HEAD})
+		BUILD_VERSION=$(git describe --tag --abbrev=2 2> /dev/null)
 	;;
 	esac
 else
@@ -246,6 +247,10 @@ echo "PRJPATH='$PRJPATH'"
 echo "PROJECT='$PROJECT'"
 echo "BRANCH='$BRANCH'"
 echo "HASHID='$HASHID'"
+if [[ -n "$BUILD_VERSION" ]]; then
+	echo "BUILD_VERSION='$BUILD_VERSION'"
+	BUILD_VERSION="--buildver=$BUILD_VERSION"
+fi
 if [[ -n "$GOPRIVATE" ]]; then
 	echo "PRIVATE='$GOPRIVATE'"
 	PRIVATE="--private=$GOPRIVATE"
@@ -254,7 +259,7 @@ fi
 TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
 
 echo Using image: $IMAGE
-echo /bin/mash.sh $ESCAPE $DARWIN $LINUX $WINDOWS $TEST $PROTO $BUILD $CACHE $PRIVATE --timestamp=$TIMESTAMP --id=$HASHID $@
+echo /bin/mash.sh $ESCAPE $DARWIN $LINUX $WINDOWS $TEST $PROTO $BUILD $CACHE $PRIVATE $BUILD_VERSION --timestamp=$TIMESTAMP --id=$HASHID $@
 
 DOCKER_VERSION="$(docker --version)"
 DOCKER_VERSION=${DOCKER_VERSION%%,*}
@@ -354,7 +359,7 @@ ${EXEC} docker run ${FLAGS} --rm \
 	$LIBS \
 	--workdir "${SRCROOT}/${PRJPATH}" \
 	${IMAGE} \
-	/bin/mash.sh $ESCAPE $DARWIN $LINUX $WINDOWS $TEST $PROTO $BUILD $CACHE $PRIVATE --timestamp=$TIMESTAMP --id=$HASHID "$@" || exit 1
+	/bin/mash.sh $ESCAPE $DARWIN $LINUX $WINDOWS $TEST $PROTO $BUILD $CACHE $PRIVATE $BUILD_VERSION --timestamp=$TIMESTAMP --id=$HASHID "$@" || exit 1
 
 if [[ $PROD == "true" ]]; then
 	make push || exit 1

--- a/masher/masher
+++ b/masher/masher
@@ -143,8 +143,6 @@ while [[ $# -gt 0 ]]; do
 	shift
 done
 
-[[ -n "${GOPRIVATE}" ]] && PRIVATE="--private=${GOPRIVATE}"
-
 if [[ -n ${PROD} ]]; then
 	LINUXFLAG="--linux"
 	DARWINFLAG="--darwin"
@@ -248,7 +246,10 @@ echo "PRJPATH='$PRJPATH'"
 echo "PROJECT='$PROJECT'"
 echo "BRANCH='$BRANCH'"
 echo "HASHID='$HASHID'"
-[[ -n "$PRIVATE" ]] && echo "PRIVATE='$PRIVATE'"
+if [[ -n "$GOPRIVATE" ]]; then
+	echo "PRIVATE='$GOPRIVATE'"
+	PRIVATE="--private=$GOPRIVATE"
+fi
 
 TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
 

--- a/masher/masher
+++ b/masher/masher
@@ -143,6 +143,8 @@ while [[ $# -gt 0 ]]; do
 	shift
 done
 
+[[ -n "${GOPRIVATE}" ]] && PRIVATE="--private=${GOPRIVATE}"
+
 if [[ -n ${PROD} ]]; then
 	LINUXFLAG="--linux"
 	DARWINFLAG="--darwin"
@@ -246,11 +248,12 @@ echo "PRJPATH='$PRJPATH'"
 echo "PROJECT='$PROJECT'"
 echo "BRANCH='$BRANCH'"
 echo "HASHID='$HASHID'"
+[[ -n "$PRIVATE" ]] && echo "PRIVATE='$PRIVATE'"
 
 TIMESTAMP=$(date -u +"%Y%m%d.%H%M%S")
 
 echo Using image: $IMAGE
-echo /bin/mash.sh $ESCAPE $DARWIN $LINUX $WINDOWS $TEST $PROTO $BUILD $CACHE --timestamp=$TIMESTAMP --id=$HASHID $@
+echo /bin/mash.sh $ESCAPE $DARWIN $LINUX $WINDOWS $TEST $PROTO $BUILD $CACHE $PRIVATE --timestamp=$TIMESTAMP --id=$HASHID $@
 
 DOCKER_VERSION="$(docker --version)"
 DOCKER_VERSION=${DOCKER_VERSION%%,*}
@@ -348,7 +351,7 @@ ${EXEC} docker run ${FLAGS} --rm \
 	$LIBS \
 	--workdir "${SRCROOT}/${PRJPATH}" \
 	${IMAGE} \
-	/bin/mash.sh $ESCAPE $DARWIN $LINUX $WINDOWS $TEST $PROTO $BUILD $CACHE --timestamp=$TIMESTAMP --id=$HASHID "$@" || exit 1
+	/bin/mash.sh $ESCAPE $DARWIN $LINUX $WINDOWS $TEST $PROTO $BUILD $CACHE $PRIVATE --timestamp=$TIMESTAMP --id=$HASHID "$@" || exit 1
 
 if [[ $PROD == "true" ]]; then
 	make push || exit 1

--- a/masher/masher
+++ b/masher/masher
@@ -287,8 +287,9 @@ LIBS=""
 [[ -d "${BASE}/.mash/cache" ]] || mkdir -p "${BASE}/.mash/cache"
 CACHE="--cache=${SRCROOT}/.mash/cache"
 
-# vgo
+# go modules
 [[ -d "${BASE}/.mash/mod" ]] || mkdir -p "${BASE}/.mash/mod"
+[[ -d "${BASE}/.mash/sumdb" ]] || mkdir -p "${BASE}/.mash/sumdb"
 
 # godep stuff
 DEP_CACHE=""
@@ -347,6 +348,7 @@ ${EXEC} docker run ${FLAGS} --rm \
 	--user "${RUNAS}" \
 	--volume "${BASE}:${SRCROOT}:rw" \
 	--volume "${BASE}/.mash/mod:/go/pkg/mod:rw" \
+	--volume "${BASE}/.mash/sumdb:/go/pkg/sumdb:rw" \
 	$DEP_CACHE \
 	$LIBS \
 	--workdir "${SRCROOT}/${PRJPATH}" \


### PR DESCRIPTION
After go1.13 support was rolled out, some additional changes to masher scripts were necessary.
* sumdb needed to be created and made available
* `GOPRIVATE` pass-through support had to be added
* in cases of vendoring, we should enable vendoring
* for vendoring we also need to avoid using the `GOFLAGS` env for `-ldflags`