### PR TITLE
Avoid truncated udp reads

### DIFF
--- a/lib/files/copy.go
+++ b/lib/files/copy.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const defaultBufferSize = 32 * 1024
+const defaultBufferSize = 64 * 1024
 
 // Copy is a context aware version of io.Copy.
 // Do not use to Discard a reader, as a canceled context would stop the read, and it would not be fully discarded.

--- a/lib/files/copy.go
+++ b/lib/files/copy.go
@@ -80,7 +80,7 @@ func Copy(ctx context.Context, dst io.Writer, src io.Reader, opts ...CopyOption)
 		w:   dst,
 	}
 
-	r := &io.LimitedReader{
+	r := &fuzzyLimitedReader{
 		R: src,
 		N: buflen,
 	}

--- a/lib/files/copy.go
+++ b/lib/files/copy.go
@@ -99,7 +99,7 @@ func Copy(ctx context.Context, dst io.Writer, src io.Reader, opts ...CopyOption)
 	next := last.Add(c.bwInterval)
 
 	for {
-		r.N = buflen // reset io.LimitedReader
+		r.N = buflen // reset fuzzyLimitedReader
 
 		if c.runningTimeout > 0 {
 			if !t.Stop() {

--- a/lib/files/copy.go
+++ b/lib/files/copy.go
@@ -9,6 +9,15 @@ import (
 
 const defaultBufferSize = 64 * 1024
 
+// ErrWatchdogExpired is returned by files.Copy, if the watchdog time expires during a read.
+var ErrWatchdogExpired error = watchdogExpiredError{}
+
+type watchdogExpiredError struct{}
+
+func (watchdogExpiredError) Error() string   { return "watchdog expired" }
+func (watchdogExpiredError) Timeout() bool   { return true }
+func (watchdogExpiredError) Temporary() bool { return true }
+
 // Copy is a context aware version of io.Copy.
 // Do not use to Discard a reader, as a canceled context would stop the read, and it would not be fully discarded.
 func Copy(ctx context.Context, dst io.Writer, src io.Reader, opts ...CopyOption) (written int64, err error) {
@@ -27,7 +36,7 @@ func Copy(ctx context.Context, dst io.Writer, src io.Reader, opts ...CopyOption)
 		// we allocate a buffer to use as a temporary buffer, rather than alloc new every time.
 		c.buffer = make([]byte, defaultBufferSize)
 	}
-	l := int64(len(c.buffer))
+	buflen := int64(len(c.buffer))
 
 	var keepingMetrics bool
 
@@ -62,6 +71,27 @@ func Copy(ctx context.Context, dst io.Writer, src io.Reader, opts ...CopyOption)
 		bwWindow = make([]bwSnippet, c.bwCount)
 	}
 
+	// Prevent an accidental write outside of returning from this function.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	w := &deadlineWriter{
+		ctx: ctx,
+		w:   dst,
+	}
+
+	r := &io.LimitedReader{
+		R: src,
+		N: buflen,
+	}
+
+	t := time.NewTimer(c.runningTimeout)
+	if c.runningTimeout <= 0 {
+		if !t.Stop() {
+			<-t.C
+		}
+	}
+
 	start := time.Now()
 
 	var bwAccum int64
@@ -69,39 +99,34 @@ func Copy(ctx context.Context, dst io.Writer, src io.Reader, opts ...CopyOption)
 	next := last.Add(c.bwInterval)
 
 	for {
-		done := make(chan struct{})
-
-		ctx := ctx          // shadow context intentionally, we might set a timeout later
-		cancel := func() {} // noop cancel
+		r.N = buflen // reset io.LimitedReader
 
 		if c.runningTimeout > 0 {
-			ctx, cancel = context.WithTimeout(ctx, c.runningTimeout)
+			if !t.Stop() {
+				<-t.C
+			}
+			t.Reset(c.runningTimeout)
 		}
-
-		w := &deadlineWriter{
-			ctx: ctx,
-			w:   dst,
-		}
-		r := io.LimitReader(src, l)
 
 		var n int64
-
+		done := make(chan struct{})
 		go func() {
 			defer close(done)
 
 			n, err = io.CopyBuffer(w, r, c.buffer)
 
-			if n < l && err == nil {
+			if n < buflen && err == nil {
 				err = io.EOF
 			}
 		}()
 
 		select {
 		case <-done:
-			cancel()
+
+		case <-t.C:
+			return written, ErrWatchdogExpired
 
 		case <-ctx.Done():
-			cancel()
 			return written, ctx.Err()
 		}
 

--- a/lib/files/fuzzy_limited_reader.go
+++ b/lib/files/fuzzy_limited_reader.go
@@ -1,0 +1,25 @@
+package files
+
+import (
+	"io"
+)
+
+// fuzzyLimitedReader reads at least N-bytes from the underlying reader.
+// It does not ensure that it reads only or at-most N-bytes.
+// Each call to Read updates N to reflect the new amount remaining.
+// Read returns EOF when N <= 0 or when the underlying R returns EOF.
+type fuzzyLimitedReader struct {
+	R io.Reader // underlying reader
+	N int64     // stop reading after at least this much
+}
+
+func (r *fuzzyLimitedReader) Read(b []byte) (n int, err error) {
+	if r.N <= 0 {
+		return 0, io.EOF
+	}
+
+	n, err = r.R.Read(b)
+	r.N -= int64(n)
+
+	return n, err
+}

--- a/lib/files/socketfiles/dgram.go
+++ b/lib/files/socketfiles/dgram.go
@@ -304,7 +304,7 @@ func (r *datagramReader) Read(b []byte) (n int, err error) {
 
 	n = copy(b, r.buf[r.read:r.cnt])
 	r.read += n
-	return n, nil
+	return n, err
 }
 
 func newDatagramReader(ctx context.Context, sock *socket) *datagramReader {

--- a/lib/files/socketfiles/dgram.go
+++ b/lib/files/socketfiles/dgram.go
@@ -246,6 +246,9 @@ func (r *datagramReader) SetPacketSize(size int) int {
 		r.buf = append(r.buf, make([]byte, size-len(r.buf))...)
 	}
 
+	if r.read > len(r.buf) {
+		r.read = len(r.buf)
+	}
 	if r.cnt > len(r.buf) {
 		r.cnt = len(r.buf)
 	}

--- a/lib/files/socketfiles/dgram.go
+++ b/lib/files/socketfiles/dgram.go
@@ -68,7 +68,7 @@ func (w *datagramWriter) SetPacketSize(size int) int {
 	w.sock.updateDelay(len(w.buf))
 
 	// Update filename.
-	w.Info.SetName(w.sock.uri())
+	w.Info.SetNameFromURL(w.sock.uri())
 
 	return prev
 }
@@ -80,7 +80,7 @@ func (w *datagramWriter) SetBitrate(bitrate int) int {
 	prev := w.sock.setBitrate(bitrate, len(w.buf))
 
 	// Update filename.
-	w.Info.SetName(w.sock.uri())
+	w.Info.SetNameFromURL(w.sock.uri())
 
 	return prev
 }
@@ -256,7 +256,7 @@ func (r *datagramReader) SetPacketSize(size int) int {
 	r.sock.maxPacketSize = len(r.buf)
 
 	// Update filename.
-	r.Info.SetName(r.sock.uri())
+	r.Info.SetNameFromURL(r.sock.uri())
 
 	return prev
 }

--- a/lib/files/socketfiles/stream.go
+++ b/lib/files/socketfiles/stream.go
@@ -28,7 +28,7 @@ func (w *streamWriter) SetBitrate(bitrate int) int {
 	prev := w.sock.setBitrate(bitrate, 1)
 
 	// Update filename.
-	w.Info.SetName(w.sock.uri())
+	w.Info.SetNameFromURL(w.sock.uri())
 
 	return prev
 }

--- a/lib/files/socketfiles/stream.go
+++ b/lib/files/socketfiles/stream.go
@@ -15,7 +15,7 @@ import (
 type streamWriter struct {
 	*wrapper.Info
 
-	mu sync.Mutex
+	mu     sync.Mutex
 	closed chan struct{}
 
 	sock *socket
@@ -25,7 +25,12 @@ func (w *streamWriter) SetBitrate(bitrate int) int {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	return w.sock.setBitrate(bitrate, 1)
+	prev := w.sock.setBitrate(bitrate, 1)
+
+	// Update filename.
+	w.Info.SetName(w.sock.uri())
+
+	return prev
 }
 
 func (w *streamWriter) Sync() error {

--- a/lib/files/socketfiles/udp_test.go
+++ b/lib/files/socketfiles/udp_test.go
@@ -19,8 +19,9 @@ func TestUDPName(t *testing.T) {
 			Port: 80,
 		},
 
-		packetSize: 188,
-		bufferSize: 1024,
+		packetSize:    188,
+		bufferSize:    1024,
+		maxPacketSize: 1316,
 
 		ttl: 100,
 		tos: 0x80,
@@ -31,7 +32,7 @@ func TestUDPName(t *testing.T) {
 	}
 
 	uri := sock.uri()
-	expected := "udp://127.0.0.2:80?buffer_size=1024&localaddr=127.0.0.1&localport=65535&max_bitrate=2048&pkt_size=188&tos=0x80&ttl=100"
+	expected := "udp://127.0.0.2:80?buffer_size=1024&localaddr=127.0.0.1&localport=65535&max_bitrate=2048&max_pkt_size=1316&pkt_size=188&tos=0x80&ttl=100"
 
 	if s := uri.String(); s != expected {
 		t.Errorf("got a bad URI, was expecting, but got:\n\t%v\n\t%v", expected, s)

--- a/lib/files/wrapper/info.go
+++ b/lib/files/wrapper/info.go
@@ -107,14 +107,14 @@ func (fi *Info) Size() int64 {
 	return fi.sz
 }
 
-// SetSize sets a new size in the Info, and also updates the ModTime to time.Now()
+// SetSize sets a new size in the Info.
 func (fi *Info) SetSize(size int) {
 	if fi == nil {
 		return
 	}
 
-	fi.mu.RLock()
-	defer fi.mu.RUnlock()
+	fi.mu.Lock()
+	defer fi.mu.Unlock()
 
 	fi.sz = int64(size)
 }

--- a/lib/files/wrapper/info.go
+++ b/lib/files/wrapper/info.go
@@ -51,6 +51,19 @@ func (fi *Info) fixName() string {
 	return fi.name
 }
 
+// SetName sets a new URI as the filename.
+func (fi *Info) SetName(uri *url.URL) {
+	if fi == nil {
+		return
+	}
+
+	fi.mu.Lock()
+	defer fi.mu.Unlock()
+
+	fi.name = ""
+	fi.uri = uri
+}
+
 // Name returns the filename of the Info, if name == "" and there is a url,
 // then it renders the url, and returns that as the name.
 func (fi *Info) Name() string {


### PR DESCRIPTION
The `files.Copy` uses an `io.LimitReader` in order to occasionally stop copying in order to update bandwidth stats, and watchdog timers. Unfortunately, if the `io.LimitReader` is set to a non-multiple of a fixed packet size, it will short-read a packet, and drop the tail of the packet in the bitbucket.

In order to mitigate this, we implement a `max_pkt_size` parameter on a datagram reader that will ensure that at least that large of a buffer is always used for reading. If less than that is used, we will read it into a buffer and then read from the buffer until it is empty before trying to read from the source again.

There is an overly safe choice here of 64 KiB which is the maximum possible IP packet size outside of a Jumbogram. Most networks will limit the packet size based on a much smaller MTU (even jumbo packets on ethernet are 9014 bytes) so this is probably unreasonable, and should generally be set to an appropriate value. As such, even if the `max_pkt_size` is set to the default, the filename will be updated to include the value.

Two more-or-less independent actions are taken in this PR to address the central issue of preventing truncated UDP reads:
* implement a buffer on the `datagramReader` to convert it from a packet reader to a stream reader.
* implement a change in the `files.Copy` behavior to avoid a shrinking read buffer.

Both of these were taken, and I decided to keep both, rather than pick one or the other, because both add a layer of guarantee against potentially unexpected “misbehavior”. Meaning even if you do use an `io.LimitedReader` on a UDP reader, it will not potentially truncate packets, and `files.Copy` behaves much better like its `io.Copy` counterpart, and uses the underlying buffer fully and effectively for every read.

The optimizations done to the `files.Copy` came from just noticing the inefficiencies, and since I was already here fixing things…