### PR TITLE
[Feature] import ideas from io/fs proposal

### DIFF
--- a/lib/files/about/about.go
+++ b/lib/files/about/about.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/puellanivis/breton/lib/files"
@@ -41,6 +40,7 @@ func (f stringFunc) ReadAll() ([]byte, error) {
 var (
 	blank   stringFunc = func() string { return "" }
 	version stringFunc = func() string { return process.Version() }
+	now     stringFunc = func() string { return time.Now().Truncate(0).String() }
 )
 
 type errorURL struct {
@@ -73,6 +73,7 @@ var (
 		"invalid":       notfound,
 		"html-kind":     unresolvable,
 		"legacy-compat": unresolvable,
+		"now":           now,
 		"plugins":       plugins,
 		"srcdoc":        unresolvable,
 		"version":       version,
@@ -264,6 +265,6 @@ func (h handler) ReadDir(ctx context.Context, uri *url.URL) ([]os.FileInfo, erro
 	return nil, &os.PathError{
 		Op:   "readdir",
 		Path: uri.String(),
-		Err:  syscall.ENOTDIR,
+		Err:  files.ErrNotDirectory,
 	}
 }

--- a/lib/files/about/about_test.go
+++ b/lib/files/about/about_test.go
@@ -1,0 +1,15 @@
+package aboutfiles
+
+import (
+	"testing"
+
+	"github.com/puellanivis/breton/lib/files"
+)
+
+func TestHandlerFulfillsReadDirFS(t *testing.T) {
+	var h files.FS = handler{}
+
+	if _, ok := h.(files.ReadDirFS); !ok {
+		t.Fatal("handler does not implement files.ReadDirFS")
+	}
+}

--- a/lib/files/cachefiles/cache.go
+++ b/lib/files/cachefiles/cache.go
@@ -4,6 +4,7 @@ package cachefiles
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/url"
 	"os"
 	"sync"
@@ -14,23 +15,20 @@ import (
 )
 
 type line struct {
-	os.FileInfo
-
+	info os.FileInfo
 	data []byte
 }
 
-// FileStore is a caching structure that holds copies of the content of files.
-type FileStore struct {
+// FS is a caching structure that holds copies of the content of files.
+type FS struct {
 	sync.RWMutex
 
 	cache map[string]*line
 }
 
-// New returns a new caching FileStore, which can be registered into lib/files
-func New() *FileStore {
-	return &FileStore{
-		cache: make(map[string]*line),
-	}
+// New returns a new caching FS, which can be registered into lib/files
+func New() *FS {
+	return &FS{}
 }
 
 // Default is the default cache attached to the "cache" Scheme
@@ -40,7 +38,7 @@ func init() {
 	files.RegisterScheme(Default, "cache")
 }
 
-func (h *FileStore) expire(filename string) {
+func (h *FS) expire(filename string) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -48,43 +46,64 @@ func (h *FileStore) expire(filename string) {
 }
 
 func trimScheme(uri *url.URL) string {
-	if uri.Scheme == "" {
-		return uri.String()
-	}
+	u := *uri
+	u.Scheme = ""
 
-	return uri.String()[len(uri.Scheme)+1:]
+	return u.String()
 }
 
-// Create implements the files.FileStore Create. At this time, it just returns the files.Create() from the wrapped url.
-func (h *FileStore) Create(ctx context.Context, uri *url.URL) (files.Writer, error) {
+// Create implements files.CreateFS.
+// At this time, it just returns the files.Create() from the wrapped url.
+func (h *FS) Create(ctx context.Context, uri *url.URL) (files.Writer, error) {
 	return files.Create(ctx, trimScheme(uri))
 }
 
-// Open implements the files.FileStore Open. It returns a buffered copy of the files.Reader returned from reading the uri escaped by the "cache:" scheme. Any access within the next ExpireTime set by the context.Context (5 minutes by default) will return a new copy of an bytes.Reader of the same buffer.
-func (h *FileStore) Open(ctx context.Context, uri *url.URL) (files.Reader, error) {
+// Open implements files.FS.
+// It returns a buffered copy of the files.Reader returned from reading the uri escaped by the "cache:" scheme.
+// Any access within the next ExpireTime set by the context.Context (or 5 minutes by default) will return a new copy of a files.Reader, with the same content.
+func (h *FS) Open(ctx context.Context, uri *url.URL) (files.Reader, error) {
+	filename := trimScheme(uri)
+
+	ctx, safe := isReentrySafe(ctx)
+	if !safe {
+		// We are in a rentrant caching scenario.
+		// Continuing will deadlock, so we won’t even try to cache at all.
+		return files.Open(ctx, filename)
+	}
+
+	fmt.Println(filename)
+
+	h.RLock()
+	f, ok := h.cache[filename]
+	h.RUnlock()
+
+	if ok {
+		return wrapper.NewReaderWithInfo(bytes.NewReader(f.data), f.info), nil
+	}
+
+	// default 5 minute expiration
+	expiration := 5 * time.Minute
+	if d, ok := GetExpire(ctx); ok {
+		expiration = d
+	}
+
 	h.Lock()
 	defer h.Unlock()
 
-	filename := trimScheme(uri)
+	f, ok = h.cache[filename]
 
-	f, ok := h.cache[filename]
+	// We have to test existence again.
+	// Maybe another thread already did our work.
 
 	if !ok {
-		if _, ok := ctx.Deadline(); !ok {
-			// default 5 minute expire time
-			d := 5 * time.Minute
-			if t, ok := GetExpire(ctx); ok {
-				d = t
-			}
-
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, d)
-			defer cancel()
-		}
-
 		raw, err := files.Open(ctx, filename)
 		if err != nil {
 			return nil, err
+		}
+
+		info, err := raw.Stat()
+		if err != nil {
+			info = nil // safety guard.
 		}
 
 		data, err := files.ReadFrom(raw)
@@ -92,29 +111,33 @@ func (h *FileStore) Open(ctx context.Context, uri *url.URL) (files.Reader, error
 			return nil, err
 		}
 
-		info, err := raw.Stat()
-		if err != nil {
+		if info == nil {
 			info = wrapper.NewInfo(uri, len(data), time.Now())
 		}
 
 		f = &line{
-			data:     data,
-			FileInfo: info,
+			data: data,
+			info: info,
+		}
+
+		if h.cache == nil {
+			h.cache = make(map[string]*line)
 		}
 
 		h.cache[filename] = f
 
+		timer := time.NewTimer(expiration)
 		go func() {
-			defer h.expire(filename)
-
-			<-ctx.Done()
+			<-timer.C
+			h.expire(filename)
 		}()
 	}
 
-	return wrapper.NewReaderWithInfo(bytes.NewReader(f.data), f.FileInfo), nil
+	return wrapper.NewReaderWithInfo(bytes.NewReader(f.data), f.info), nil
 }
 
-// List implements the files.FileStore List. It does not cache anything and just returns the files.List() from the wrapped url.
-func (h *FileStore) List(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
-	return files.List(ctx, trimScheme(uri))
+// ReadDir implements files.ReadDirFS.
+// It does not cache anything and just returns the files.ReadDir() from the wrapped url.
+func (h *FS) ReadDir(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
+	return files.ReadDir(ctx, trimScheme(uri))
 }

--- a/lib/files/cachefiles/cache_test.go
+++ b/lib/files/cachefiles/cache_test.go
@@ -1,0 +1,23 @@
+package cachefiles
+
+import (
+	"testing"
+
+	"github.com/puellanivis/breton/lib/files"
+)
+
+func TestHandlerFulfillsReadDirFS(t *testing.T) {
+	var h files.FS = &FS{}
+
+	if _, ok := h.(files.ReadDirFS); !ok {
+		t.Fatal("handler does not implement files.ReadDirFS")
+	}
+}
+
+func TestHandlerFulfillsCreateFS(t *testing.T) {
+	var h files.FS = &FS{}
+
+	if _, ok := h.(files.ReadDirFS); !ok {
+		t.Fatal("handler does not implement files.ReadDirFS")
+	}
+}

--- a/lib/files/cachefiles/context.go
+++ b/lib/files/cachefiles/context.go
@@ -6,7 +6,8 @@ import (
 )
 
 type (
-	expireKey struct{}
+	expireKey     struct{}
+	reentranceKey struct{}
 )
 
 // WithExpire returns a Context that includes information for the cache FileStore to expire buffers after the given timeout.
@@ -19,4 +20,12 @@ func GetExpire(ctx context.Context) (time.Duration, bool) {
 	timeout, ok := ctx.Value(expireKey{}).(time.Duration)
 
 	return timeout, ok
+}
+
+func isReentrySafe(ctx context.Context) (context.Context, bool) {
+	if v := ctx.Value(reentranceKey{}); v != nil {
+		return ctx, false
+	}
+
+	return context.WithValue(ctx, reentranceKey{}, struct{}{}), true
 }

--- a/lib/files/clipboard/clip.go
+++ b/lib/files/clipboard/clip.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"net/url"
 	"os"
-	"syscall"
 	"time"
 
 	"github.com/puellanivis/breton/lib/files"
@@ -44,7 +43,7 @@ func getClip(uri *url.URL) (clipboard, error) {
 	return clip, nil
 }
 
-func (h *handler) Open(ctx context.Context, uri *url.URL) (files.Reader, error) {
+func (handler) Open(ctx context.Context, uri *url.URL) (files.Reader, error) {
 	clip, err := getClip(uri)
 	if err != nil {
 		return nil, files.PathError("open", uri.String(), err)
@@ -58,7 +57,7 @@ func (h *handler) Open(ctx context.Context, uri *url.URL) (files.Reader, error) 
 	return wrapper.NewReaderFromBytes(b, uri, time.Now()), nil
 }
 
-func (h *handler) Create(ctx context.Context, uri *url.URL) (files.Writer, error) {
+func (handler) Create(ctx context.Context, uri *url.URL) (files.Writer, error) {
 	clip, err := getClip(uri)
 	if err != nil {
 		return nil, files.PathError("create", uri.String(), err)
@@ -69,9 +68,13 @@ func (h *handler) Create(ctx context.Context, uri *url.URL) (files.Writer, error
 	}), nil
 }
 
-func (h *handler) List(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
+func (handler) ReadDir(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
 	if uri.Host != "" || uri.User != nil {
-		return nil, files.PathError("readdir", uri.String(), os.ErrInvalid)
+		return nil, &os.PathError{
+			Op:   "readdir",
+			Path: uri.String(),
+			Err:  os.ErrInvalid,
+		}
 	}
 
 	path := uri.Path
@@ -81,22 +84,42 @@ func (h *handler) List(ctx context.Context, uri *url.URL) ([]os.FileInfo, error)
 
 	clip := clipboards[path]
 	if clip == nil {
-		return nil, files.PathError("readdir", uri.String(), os.ErrNotExist)
+		return nil, &os.PathError{
+			Op:   "readdir",
+			Path: uri.String(),
+			Err:  os.ErrNotExist,
+		}
 	}
 
 	if path != "" {
-		return nil, files.PathError("readdir", uri.String(), syscall.ENOTDIR)
-	}
-
-	if len(clipboards) < 1 {
-		return nil, files.PathError("readdir", uri.String(), os.ErrNotExist)
+		return nil, &os.PathError{
+			Op:   "readdir",
+			Path: uri.String(),
+			Err:  files.ErrNotDirectory,
+		}
 	}
 
 	var ret []os.FileInfo
 
 	for _, clip := range clipboards {
-		if fi, err := clip.Stat(); err == nil {
-			ret = append(ret, fi)
+		if info, err := clip.Stat(); err == nil {
+			if fi, ok := info.(interface{ URL() *url.URL }); ok {
+				u := fi.URL()
+				u.Scheme = ""
+
+				switch fi := fi.(type) {
+				case interface{ SetNameFromURL(*url.URL) }:
+					fi.SetNameFromURL(u)
+
+				case interface{ SetName(string) }:
+					fi.SetName(u.String())
+
+				default:
+					info = wrapper.NewInfo(u, int(info.Size()), info.ModTime())
+				}
+			}
+
+			ret = append(ret, info)
 		}
 	}
 

--- a/lib/files/create.go
+++ b/lib/files/create.go
@@ -4,12 +4,18 @@ import (
 	"context"
 	"net/url"
 	"os"
-	"path/filepath"
 )
 
-// Create takes a context and a filename (which may be a URL) and returns a
-// files.Writer that allows writing data to that local filename or URL. All
-// errors and reversion functions returned by Option arguments are discarded.
+// CreateFS defines an extention interface on FS, which also provides an ability to create a new file for read/write.
+type CreateFS interface {
+	FS
+	Create(ctx context.Context, uri *url.URL) (Writer, error)
+}
+
+// Create takes a context and a filename (which may be a URL) and
+// returns a files.Writer that allows writing data to that local filename or URL.
+//
+// All errors and reversion functions returned by Option arguments are discarded.
 func Create(ctx context.Context, filename string, options ...Option) (Writer, error) {
 	f, err := create(ctx, filename)
 	if err != nil {
@@ -31,17 +37,30 @@ func create(ctx context.Context, filename string) (Writer, error) {
 		return os.Stderr, nil
 	}
 
-	if filepath.IsAbs(filename) {
+	uri := parsePath(ctx, filename)
+	if isPath(uri) {
 		return os.Create(filename)
 	}
 
-	if uri, err := url.Parse(filename); err == nil {
-		uri = resolveFilename(ctx, uri)
-
-		if fs, ok := getFS(uri); ok {
-			return fs.Create(ctx, uri)
+	fsys, ok := getFS(uri)
+	if !ok {
+		return nil, &os.PathError{
+			Op:   "readdir",
+			Path: uri.String(),
+			Err:  ErrNotSupported,
 		}
 	}
 
-	return os.Create(filename)
+	switch fsys := fsys.(type) {
+	case CreateFS:
+		return fsys.Create(ctx, uri)
+
+		// case OpenFileFS: // implement
+	}
+
+	return nil, &os.PathError{
+		Op:   "readdir",
+		Path: filename,
+		Err:  ErrNotSupported,
+	}
 }

--- a/lib/files/errors.go
+++ b/lib/files/errors.go
@@ -1,6 +1,7 @@
 package files
 
 import (
+	"errors"
 	"os"
 )
 
@@ -15,3 +16,6 @@ func PathError(op, path string, err error) error {
 		Err:  err,
 	}
 }
+
+// ErrNotSupported should be returned, if a particular feature or option is not supported.
+var ErrNotSupported = errors.New("not supported")

--- a/lib/files/errors.go
+++ b/lib/files/errors.go
@@ -3,6 +3,7 @@ package files
 import (
 	"errors"
 	"os"
+	"syscall"
 )
 
 // PathError returns an *os.PathError with appropriate fields set. DO NOT USE.
@@ -17,5 +18,10 @@ func PathError(op, path string, err error) error {
 	}
 }
 
-// ErrNotSupported should be returned, if a particular feature or option is not supported.
-var ErrNotSupported = errors.New("not supported")
+var (
+	// ErrNotSupported should be returned, if a particular feature or option is not supported.
+	ErrNotSupported = errors.New("not supported")
+
+	// ErrNotDirectory should be returned, if a request is made to ReadDir a non-directory.
+	ErrNotDirectory = syscall.ENOTDIR
+)

--- a/lib/files/files.go
+++ b/lib/files/files.go
@@ -84,22 +84,33 @@ import (
 	"os"
 )
 
-// File defines an interface that abstracts the concept of files to allow for multiple types implementation, beyond the local filesystem.
+// File defines an interface that abstracts the central core concepts of files, for broad implementation.
 type File interface {
 	io.Closer
 	Name() string
 	Stat() (os.FileInfo, error)
 }
 
-// Reader defines a files.File that is also an io.ReadSeeker
+// Reader defines an extension interface on files.File that is also an io.Reader.
 type Reader interface {
 	File
-	io.ReadSeeker
+	io.Reader
 }
 
-// Writer defines a files.File that is also an io.Writer with a Sync() function.
+// SeekReader defines an extension interface on files.Reader that is also an io.Seeker
+type SeekReader interface {
+	Reader
+	io.Seeker
+}
+
+// Writer defines an extention interface on files.File that is also an io.Writer.
 type Writer interface {
 	File
 	io.Writer
+}
+
+// SyncWriter defines an extension interface on files.Writer that also supports Sync().
+type SyncWriter interface {
+	Writer
 	Sync() error
 }

--- a/lib/files/filestore.go
+++ b/lib/files/filestore.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net/url"
 	"os"
-	"sort"
-	"sync"
 )
 
 // FileStore defines an interface which implements a system of accessing files for reading (Open) writing (Write) and directly listing (List)
@@ -13,64 +11,4 @@ type FileStore interface {
 	Open(ctx context.Context, uri *url.URL) (Reader, error)
 	Create(ctx context.Context, uri *url.URL) (Writer, error)
 	List(ctx context.Context, uri *url.URL) ([]os.FileInfo, error)
-}
-
-var fsMap struct {
-	sync.Mutex
-
-	m      map[string]FileStore
-	keys   []string
-	sorted bool
-}
-
-func getFS(uri *url.URL) (FileStore, bool) {
-	fsMap.Lock()
-	defer fsMap.Unlock()
-
-	if fsMap.m == nil {
-		return nil, false
-	}
-
-	fs, ok := fsMap.m[uri.Scheme]
-	return fs, ok
-}
-
-// RegisterScheme takes a FileStore and attaches to it the given schemes so
-// that files.Open will use that FileStore when a files.Open() is performed
-// with a URL of any of those schemes.
-func RegisterScheme(fs FileStore, schemes ...string) {
-	if len(schemes) < 1 {
-		return
-	}
-
-	fsMap.Lock()
-	defer fsMap.Unlock()
-
-	if fsMap.m == nil {
-		fsMap.m = make(map[string]FileStore)
-	}
-	fsMap.sorted = false
-
-	for _, scheme := range schemes {
-		if _, ok := fsMap.m[scheme]; ok {
-			// TODO: report duplicate scheme registration
-			continue
-		}
-
-		fsMap.m[scheme] = fs
-		fsMap.keys = append(fsMap.keys, scheme)
-	}
-}
-
-// RegisteredSchemes returns a slice of strings that describe all registered schemes.
-func RegisteredSchemes() []string {
-	fsMap.Lock()
-	defer fsMap.Unlock()
-
-	if !fsMap.sorted {
-		sort.Strings(fsMap.keys)
-		fsMap.sorted = true
-	}
-
-	return fsMap.keys
 }

--- a/lib/files/filesystem.go
+++ b/lib/files/filesystem.go
@@ -1,0 +1,69 @@
+package files
+
+import (
+	"context"
+	"net/url"
+	"sort"
+	"sync"
+)
+
+// FS defines an interface, which implements a minimal set of functionality for a filesystem from this package.
+type FS interface {
+	Open(ctx context.Context, uri *url.URL) (Reader, error)
+}
+
+var fsMap struct {
+	sync.Mutex
+
+	m      map[string]FS
+	keys   []string
+	sorted bool
+}
+
+func getFS(uri *url.URL) (FS, bool) {
+	fsMap.Lock()
+	defer fsMap.Unlock()
+
+	fs, ok := fsMap.m[uri.Scheme]
+	return fs, ok
+}
+
+// RegisterScheme takes an FS and attaches to it the given schemes so
+// that files.Open will use that FS when a files.Open() is performed
+// with a URL with any of those schemes.
+func RegisterScheme(fs FS, schemes ...string) {
+	if len(schemes) < 1 {
+		return
+	}
+
+	fsMap.Lock()
+	defer fsMap.Unlock()
+
+	if fsMap.m == nil {
+		fsMap.m = make(map[string]FS)
+	}
+	fsMap.sorted = false
+
+	for _, scheme := range schemes {
+		if _, ok := fsMap.m[scheme]; ok {
+			// TODO: report duplicate scheme registration
+			continue
+		}
+
+		fsMap.m[scheme] = fs
+		fsMap.keys = append(fsMap.keys, scheme)
+	}
+}
+
+// RegisteredSchemes returns a slice of strings that describe all registered schemes.
+func RegisteredSchemes() []string {
+	fsMap.Lock()
+	defer fsMap.Unlock()
+
+	if !fsMap.sorted {
+		sort.Strings(fsMap.keys)
+		fsMap.sorted = true
+	}
+
+	return append([]string(nil), fsMap.keys...)
+}

--- a/lib/files/local.go
+++ b/lib/files/local.go
@@ -2,6 +2,7 @@ package files
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -9,33 +10,33 @@ import (
 
 type localFS struct{}
 
-// Local implements a wrapper from the os functions Open, Create, and Readdir, to the files.FileStore implementation.
-var Local FileStore = &localFS{}
+// Local implements a wrapper from os.Open, os.Create, and os.Readdir, to the files.FS implementation.
+var Local FS = localFS{}
 
 func init() {
 	RegisterScheme(Local, "file")
 }
 
 func filename(uri *url.URL) string {
-	fname := uri.Path
-	if fname == "" {
-		fname = uri.Opaque
+	if uri.Path != "" {
+		return uri.Path
 	}
 
-	return fname
+	return uri.Opaque
 }
 
 // Open opens up a local filesystem file specified in the uri.Path for reading.
-func (h *localFS) Open(ctx context.Context, uri *url.URL) (Reader, error) {
+func (localFS) Open(ctx context.Context, uri *url.URL) (Reader, error) {
+	fmt.Println("os.Open:", filename(uri))
 	return os.Open(filename(uri))
 }
 
 // Create opens up a local filesystem file specified in the uri.Path for writing. It will create a new one if it does not exist.
-func (h *localFS) Create(ctx context.Context, uri *url.URL) (Writer, error) {
+func (localFS) Create(ctx context.Context, uri *url.URL) (Writer, error) {
 	return os.Create(filename(uri))
 }
 
 // List returns the whole slice of os.FileInfos for a specific local filesystem at uri.Path.
-func (h *localFS) List(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
+func (localFS) ReadDir(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
 	return ioutil.ReadDir(filename(uri))
 }

--- a/lib/files/option.go
+++ b/lib/files/option.go
@@ -1,14 +1,9 @@
 package files
 
 import (
-	"errors"
 	"os"
 	"time"
 )
-
-// ErrNotSupported should be returned when a specific file.File given to an
-// Option does not support the Option specified.
-var ErrNotSupported = errors.New("option not supported")
 
 // Option is a function that applies a specific option to a files.File, it
 // returns an Option and and error. If error is not nil, then the Option

--- a/lib/files/path.go
+++ b/lib/files/path.go
@@ -7,64 +7,80 @@ import (
 )
 
 func isPath(uri *url.URL) bool {
-	if uri.IsAbs() {
+	switch {
+	case uri.IsAbs():
 		return false
-	}
 
-	if uri.User != nil {
+	case uri.User != nil:
 		return false
-	}
 
-	if len(uri.Host)+len(uri.RawQuery)+len(uri.Fragment) > 0 {
+	case len(uri.Host)+len(uri.RawQuery)+len(uri.Fragment) > 0:
 		return false
-	}
 
-	if uri.ForceQuery {
+	case uri.ForceQuery:
 		return false
 	}
 
 	return true
 }
 
-func getPath(uri *url.URL) string {
-	if uri.RawPath != "" {
-		return uri.RawPath
-	}
-
-	return uri.Path
-}
-
-func makePath(path string) *url.URL {
-	return &url.URL{
-		Path:    path,
-		RawPath: path,
-	}
-}
-
-func resolveFilename(ctx context.Context, uri *url.URL) *url.URL {
+func resolveURL(ctx context.Context, uri *url.URL) *url.URL {
 	if uri.IsAbs() {
+		// short-circuit: If the url is absolute,
+		// then we should never consider resolving it as a reference relative to root.
 		return uri
 	}
 
-	var path string
+	if root, ok := getRoot(ctx); ok {
+		switch {
+		case !isPath(root):
+			// If root is not a path-only URL,
+			// then always resolve the uri as a reference.
+			return root.ResolveReference(uri)
+
+		case isPath(uri):
+			// special-case: If both root and uri are wrapped simple paths,
+			// then join their Paths through filepath.Join,
+			// instead of using URL path handling.
+			return &url.URL{
+				Path: filepath.Join(root.Path, uri.Path),
+			}
+		}
+
+		// root is a wrapped simple path, but uri is not,
+		// there’s no good way to really join these two together.
+		// fallthrough to not even considering root.
+	}
 
 	if isPath(uri) {
-		path = getPath(uri)
+		uri.Path = filepath.Clean(uri.Path)
+	}
 
-		if filepath.IsAbs(path) {
-			return makePath(path)
+	return uri
+}
+
+// parsePath will always return a non-nil `*url.URL`.
+//
+// If the path is an invalid URL, then we will return a wrapped simple path,
+// which is simply a &url.URL{ Path: path }.
+func parsePath(ctx context.Context, path string) *url.URL {
+	if filepath.IsAbs(path) {
+		// If for this architecture, path is an an absolute path
+		// then we should only ever treat it as a wrapped simple path.
+		return &url.URL{
+			Path: filepath.Clean(path),
 		}
 	}
 
-	root, ok := getRoot(ctx)
-	if !ok {
-		return uri
+	uri, err := url.Parse(path)
+	if err != nil {
+		// If this path fails to parse as a URL, treat it like a wrapped simple path.
+		uri = &url.URL{
+			Path: path,
+		}
 	}
 
-	if path != "" && isPath(root) {
-		return makePath(filepath.Join(getPath(root), path))
-
-	}
-
-	return root.ResolveReference(uri)
+	// Since we do not `filepath.Clean` the wrapped simple path from above,
+	// this function must assure that the wrapped simple path is cleaned before returning the url.
+	return resolveURL(ctx, uri)
 }

--- a/lib/files/read.go
+++ b/lib/files/read.go
@@ -6,7 +6,8 @@ import (
 	"io/ioutil"
 )
 
-// ReadFrom reads the entire content of an io.ReadCloser and returns the content as a byte slice. It will also Close the reader.
+// ReadFrom reads the entire content of an io.ReadCloser and returns the content as a byte slice.
+// It will also Close the reader.
 func ReadFrom(r io.ReadCloser) ([]byte, error) {
 	b, err := ioutil.ReadAll(r)
 	if err1 := r.Close(); err == nil {
@@ -15,7 +16,7 @@ func ReadFrom(r io.ReadCloser) ([]byte, error) {
 	return b, err
 }
 
-// Discard throws away the entire content of an io.ReadCloser and closes the reader.
+// Discard throws away the entire content of an io.ReadCloser and then closes the reader.
 // This is specifically not context aware, it is intended to always run to completion.
 func Discard(r io.ReadCloser) error {
 	_, err := io.Copy(ioutil.Discard, r)

--- a/lib/files/readdir.go
+++ b/lib/files/readdir.go
@@ -1,0 +1,90 @@
+package files
+
+import (
+	"context"
+	"io/ioutil"
+	"net/url"
+	"os"
+)
+
+// ReadDirFS defines an extension interface on FS, which also provides an ability to enumerate files given a prefix.
+type ReadDirFS interface {
+	FS
+	ReadDir(ctx context.Context, uri *url.URL) ([]os.FileInfo, error)
+}
+
+// ReadDir takes a context and a filename (which may be a URL) and
+// returns a slice of `os.FileInfo` that describes the files contained in the directory or listing.
+func ReadDir(ctx context.Context, filename string) ([]os.FileInfo, error) {
+	switch filename {
+	case "", "-", "/dev/stdin":
+		return os.Stdin.Readdir(0)
+	}
+
+	uri := parsePath(ctx, filename)
+	if isPath(uri) {
+		return ioutil.ReadDir(filename)
+	}
+
+	fsys, ok := getFS(uri)
+	if !ok {
+		return nil, &os.PathError{
+			Op:   "readdir",
+			Path: uri.String(),
+			Err:  ErrNotSupported,
+		}
+	}
+
+	switch fsys := fsys.(type) {
+	case ReadDirFS:
+		return fsys.ReadDir(ctx, uri)
+
+	case FileStore:
+		return fsys.List(ctx, uri)
+	}
+
+	return nil, &os.PathError{
+		Op:   "readdir",
+		Path: filename,
+		Err:  ErrNotSupported,
+	}
+}
+
+// List takes a context and a filename (which may be a URL) and
+// returns a slice of `os.FileInfo` that describes the files contained in the directory or listing.
+//
+// DEPRECATED: use `ReadDir`.
+func List(ctx context.Context, filename string) ([]os.FileInfo, error) {
+	switch filename {
+	case "", "-", "/dev/stdin":
+		return os.Stdin.Readdir(0)
+	}
+
+	uri := parsePath(ctx, filename)
+	if isPath(uri) {
+		return ioutil.ReadDir(filename)
+	}
+
+	fsys, ok := getFS(uri)
+	if !ok {
+		return nil, &os.PathError{
+			Op:   "readdir",
+			Path: uri.String(),
+			Err:  ErrNotSupported,
+		}
+	}
+
+	switch fsys := fsys.(type) {
+	case ReadDirFS:
+		return fsys.ReadDir(ctx, uri)
+
+	case FileStore:
+		return fsys.List(ctx, uri)
+	}
+
+	return nil, &os.PathError{
+		Op:   "readdir",
+		Path: filename,
+		Err:  ErrNotSupported,
+	}
+}

--- a/lib/files/wrapper/info.go
+++ b/lib/files/wrapper/info.go
@@ -95,6 +95,35 @@ func (fi *Info) Name() string {
 	return name
 }
 
+// URL returns the URL of the Info, if there is no URL yet,
+// then it will set the URL to be `&url.URL{ Path: name }`.
+func (fi *Info) URL() *url.URL {
+	if fi == nil {
+		return &url.URL{}
+	}
+
+	fi.mu.RLock()
+	uri := fi.uri
+	fi.mu.RUnlock()
+
+	if uri != nil {
+		u := *uri
+		return &u
+	}
+
+	fi.mu.Lock()
+	defer fi.mu.Unlock()
+
+	if fi.uri == nil {
+		fi.uri = &url.URL{
+			Path: fi.name,
+		}
+	}
+
+	u := *fi.uri
+	return &u
+}
+
 // Size returns the size declared in the Info.
 func (fi *Info) Size() int64 {
 	if fi == nil {


### PR DESCRIPTION
In the current proposal about `io/fs` the design of using a basic minimal core interface, and then extension interfaces to expand optional features is a great one. There are a number of handlers that I have that cannot do lists, or `ReadDir`s, and as of now, they had to be written to return an opaque not supported error.

With the new design idea of extension interfaces, we can just not implement them, and allow them to be automatically handled earlier up the tree.

As I’m going through, I’m also clearing out `files.PathError` calls to direct `&os.PathError{}` (finally), and squishing bugs as I find them.