### PR TITLE
cachefiles: bugfixes and simplification

### DIFF
--- a/lib/files/cachefiles/cache.go
+++ b/lib/files/cachefiles/cache.go
@@ -26,12 +26,15 @@ type FileStore struct {
 }
 
 // New returns a new caching FileStore, which can be registered into lib/files
+//
+// Deprecated: Now that we use sensible defaults, and lazy initialization,
+// a simple &cachefiles.FileStore{} or new(cachefiles.FileStore) is enough now.
 func New() *FileStore {
 	return &FileStore{}
 }
 
 // Default is the default cache attached to the "cache" Scheme
-var Default = New()
+var Default = new(FileStore)
 
 func init() {
 	files.RegisterScheme(Default, "cache")

--- a/lib/files/cachefiles/cache.go
+++ b/lib/files/cachefiles/cache.go
@@ -92,7 +92,7 @@ func (h *FileStore) Open(ctx context.Context, uri *url.URL) (files.Reader, error
 
 	info, err := raw.Stat()
 	if err != nil {
-		// Just in case, if we return an err != nil,
+		// Just in case, if we got an err != nil return,
 		// we want to be absolutely sure we don‘t try and use the returned `info`.
 		// Instead, we will make up our own.
 		info = nil

--- a/lib/files/cachefiles/cache.go
+++ b/lib/files/cachefiles/cache.go
@@ -93,7 +93,7 @@ func (h *FileStore) Open(ctx context.Context, uri *url.URL) (files.Reader, error
 	info, err := raw.Stat()
 	if err != nil {
 		// Just in case, if we got an err != nil return,
-		// we want to be absolutely sure we don‘t try and use the returned `info`.
+		// we want to be absolutely sure we don’t try and use the returned `info`.
 		// Instead, we will make up our own.
 		info = nil
 	}

--- a/lib/files/cachefiles/cache.go
+++ b/lib/files/cachefiles/cache.go
@@ -64,7 +64,7 @@ func (h *FileStore) Open(ctx context.Context, uri *url.URL) (files.Reader, error
 	ctx, reentrant := isReentrant(ctx)
 	if reentrant {
 		// We are in a reentrant caching scenario.
-		// Continuing will deadlock, so we won‘t even try to cache at all.
+		// Continuing will deadlock, so we won’t even try to cache at all.
 		return files.Open(ctx, filename)
 	}
 

--- a/lib/files/cachefiles/cache.go
+++ b/lib/files/cachefiles/cache.go
@@ -78,8 +78,7 @@ func (h *FileStore) Open(ctx context.Context, uri *url.URL) (files.Reader, error
 
 	f = h.cache[filename]
 	if f != nil {
-		// We have to test existance again.
-		// Maybe another goroutine already did our work.
+		// Another goroutine already did our work.
 		return wrapper.NewReaderWithInfo(bytes.NewReader(f.data), f.info), nil
 	}
 
@@ -90,7 +89,10 @@ func (h *FileStore) Open(ctx context.Context, uri *url.URL) (files.Reader, error
 
 	info, err := raw.Stat()
 	if err != nil {
-		info = nil // safety guard
+		// Just in case, if we return an err != nil,
+		// we want to be absolutely sure we don‘t try and use the returned `info`.
+		// Instead, we will make up our own.
+		info = nil
 	}
 
 	data, err := files.ReadFrom(raw)

--- a/lib/files/cachefiles/cache.go
+++ b/lib/files/cachefiles/cache.go
@@ -78,12 +78,6 @@ func (h *FileStore) Open(ctx context.Context, uri *url.URL) (files.Reader, error
 		return wrapper.NewReaderWithInfo(bytes.NewReader(f.data), f.info), nil
 	}
 
-	// default 5 minute expiration
-	expiration := 5 * time.Minute
-	if d, ok := GetExpire(ctx); ok {
-		expiration = d
-	}
-
 	h.Lock()
 	defer h.Unlock()
 
@@ -124,6 +118,11 @@ func (h *FileStore) Open(ctx context.Context, uri *url.URL) (files.Reader, error
 
 	h.cache[filename] = f
 
+	// default 5 minute expiration
+	expiration := 5 * time.Minute
+	if d, ok := GetExpire(ctx); ok {
+		expiration = d
+	}
 	timer := time.NewTimer(expiration)
 
 	go func() {

--- a/lib/files/cachefiles/cache.go
+++ b/lib/files/cachefiles/cache.go
@@ -51,11 +51,6 @@ func trimScheme(uri *url.URL) string {
 	return u.String()
 }
 
-// Create implements the files.FileStore Create. At this time, it just returns the files.Create() from the wrapped url.
-func (h *FileStore) Create(ctx context.Context, uri *url.URL) (files.Writer, error) {
-	return files.Create(ctx, trimScheme(uri))
-}
-
 // Open implements the files.FileStore Open. It returns a buffered copy of the files.Reader returned from reading the uri escaped by the "cache:" scheme. Any access within the next ExpireTime set by the context.Context (5 minutes by default) will return a new copy of an bytes.Reader of the same buffer.
 func (h *FileStore) Open(ctx context.Context, uri *url.URL) (files.Reader, error) {
 	h.Lock()
@@ -131,6 +126,11 @@ func (h *FileStore) Open(ctx context.Context, uri *url.URL) (files.Reader, error
 	}()
 
 	return wrapper.NewReaderWithInfo(bytes.NewReader(data), info), nil
+}
+
+// Create implements the files.FileStore Create. At this time, it just returns the files.Create() from the wrapped url.
+func (h *FileStore) Create(ctx context.Context, uri *url.URL) (files.Writer, error) {
+	return files.Create(ctx, trimScheme(uri))
 }
 
 // List implements the files.FileStore List. It does not cache anything and just returns the files.List() from the wrapped url.

--- a/lib/files/cachefiles/cache.go
+++ b/lib/files/cachefiles/cache.go
@@ -71,18 +71,18 @@ func (h *FileStore) Open(ctx context.Context, uri *url.URL) (files.Reader, error
 	}
 
 	h.RLock()
-	f, ok := h.cache[filename]
+	f := h.cache[filename]
 	h.RUnlock()
 
-	if ok {
+	if f != nil {
 		return wrapper.NewReaderWithInfo(bytes.NewReader(f.data), f.info), nil
 	}
 
 	h.Lock()
 	defer h.Unlock()
 
-	f, ok = h.cache[filename]
-	if ok {
+	f = h.cache[filename]
+	if f != nil {
 		// We have to test existance again.
 		// Maybe another goroutine already did our work.
 		return wrapper.NewReaderWithInfo(bytes.NewReader(f.data), f.info), nil

--- a/lib/files/cachefiles/context.go
+++ b/lib/files/cachefiles/context.go
@@ -6,18 +6,18 @@ import (
 )
 
 type (
-	expireKey     struct{}
-	reentranceKey struct{}
+	keyExpiration struct{}
+	keyReentrance struct{}
 )
 
 // WithExpire returns a Context that includes information for the cache FileStore to expire buffers after the given timeout.
 func WithExpire(ctx context.Context, timeout time.Duration) context.Context {
-	return context.WithValue(ctx, expireKey{}, timeout)
+	return context.WithValue(ctx, keyExpiration{}, timeout)
 }
 
 // GetExpire returns the expiration timeout specified for the given Context.
 func GetExpire(ctx context.Context) (time.Duration, bool) {
-	timeout, ok := ctx.Value(expireKey{}).(time.Duration)
+	timeout, ok := ctx.Value(keyExpiration{}).(time.Duration)
 
 	return timeout, ok
 }
@@ -26,9 +26,9 @@ func GetExpire(ctx context.Context) (time.Duration, bool) {
 // a new sub-context with a reentrance key attached, along with a false bool,
 // or the same context input with a true bool.
 func isReentrant(ctx context.Context) (rctx context.Context, reentrant bool) {
-	if v := ctx.Value(reentranceKey{}); v != nil {
+	if v := ctx.Value(keyReentrance{}); v != nil {
 		return ctx, true
 	}
 
-	return context.WithValue(ctx, reentranceKey{}, struct{}{}), false
+	return context.WithValue(ctx, keyReentrance{}, struct{}{}), false
 }

--- a/lib/files/cachefiles/context.go
+++ b/lib/files/cachefiles/context.go
@@ -6,7 +6,8 @@ import (
 )
 
 type (
-	expireKey struct{}
+	expireKey     struct{}
+	reentranceKey struct{}
 )
 
 // WithExpire returns a Context that includes information for the cache FileStore to expire buffers after the given timeout.
@@ -19,4 +20,15 @@ func GetExpire(ctx context.Context) (time.Duration, bool) {
 	timeout, ok := ctx.Value(expireKey{}).(time.Duration)
 
 	return timeout, ok
+}
+
+// isReentrant returns either:
+// a new sub-context with a reentrance key attached, along with a false bool,
+// or the same context input with a true bool.
+func isReentrant(ctx context.Context) (rctx context.Context, reentrant bool) {
+	if v := ctx.Value(reentranceKey{}); v != nil {
+		return ctx, true
+	}
+
+	return context.WithValue(ctx, reentranceKey{}, struct{}{}), false
 }


### PR DESCRIPTION
As part of the `io/fs` designs I came across some bugs with the `cache:` handler. Namely, it does not handle reentrant filenames. And the code was far more complicated than it needed to be. By breaking things up and using early returns, we can make functionality building up.