### PR TITLE
Fix FileDescriptor scheme (`fd:`) to work for negative Windows FileHandles

### DIFF
--- a/lib/files/fd.go
+++ b/lib/files/fd.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/url"
 	"os"
-	"strconv"
+	"strings"
 )
 
 type descriptorHandler struct{}
@@ -13,29 +13,69 @@ func init() {
 	RegisterScheme(&descriptorHandler{}, "fd")
 }
 
-func (h *descriptorHandler) open(uri *url.URL) (*os.File, error) {
-	fd, err := strconv.ParseUint(filename(uri), 0, 64)
+func openFD(uri *url.URL) (*os.File, error) {
+	if uri.Host != "" || uri.User != nil {
+		return nil, os.ErrInvalid
+	}
+
+	num := strings.TrimPrefix(uri.Path, "/")
+	if num == "" {
+		var err error
+		num, err = url.PathUnescape(uri.Opaque)
+		if err != nil {
+			return nil, os.ErrInvalid
+		}
+	}
+
+	fd, err := resolveFileHandle(num)
 	if err != nil {
 		return nil, err
+	}
+
+	// Canonicalize the name.
+	uri = &url.URL{
+		Scheme: "fd",
+		Opaque: url.PathEscape(num),
 	}
 
 	return os.NewFile(uintptr(fd), uri.String()), nil
 }
 
-func (h *descriptorHandler) Open(ctx context.Context, uri *url.URL) (Reader, error) {
-	return h.open(uri)
-}
-
-func (h *descriptorHandler) Create(ctx context.Context, uri *url.URL) (Writer, error) {
-	return h.open(uri)
-}
-
-func (h *descriptorHandler) List(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
-	f, err := h.open(uri)
+func (*descriptorHandler) Open(ctx context.Context, uri *url.URL) (Reader, error) {
+	f, err := openFD(uri)
 	if err != nil {
-		return nil, err
+		return nil, &os.PathError{
+			Op:   "open",
+			Path: uri.String(),
+			Err:  err,
+		}
 	}
-	defer f.Close()
+
+	return f, nil
+}
+
+func (*descriptorHandler) Create(ctx context.Context, uri *url.URL) (Writer, error) {
+	f, err := openFD(uri)
+	if err != nil {
+		return nil, &os.PathError{
+			Op:   "create",
+			Path: uri.String(),
+			Err:  err,
+		}
+	}
+
+	return f, nil
+}
+
+func (*descriptorHandler) List(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
+	f, err := openFD(uri)
+	if err != nil {
+		return nil, &os.PathError{
+			Op:   "open",
+			Path: uri.String(),
+			Err:  err,
+		}
+	}
 
 	return f.Readdir(0)
 }

--- a/lib/files/fileresolve_posix.go
+++ b/lib/files/fileresolve_posix.go
@@ -1,0 +1,17 @@
+// +build dragonflybsd freebsd linux netbsd openbsd solaris darwin
+
+package files
+
+import (
+	"os"
+	"strconv"
+)
+
+func resolveFileHandle(num string) (uintptr, error) {
+	fd, err := strconv.ParseUint(num, 0, strconv.IntSize)
+	if err != nil {
+		return uintptr(^fd), os.ErrInvalid
+	}
+
+	return uintptr(fd), nil
+}

--- a/lib/files/fileresolve_windows.go
+++ b/lib/files/fileresolve_windows.go
@@ -1,0 +1,15 @@
+package files
+
+import (
+	"os"
+	"strconv"
+)
+
+func resolveFileHandle(num string) (uintptr, error) {
+	fd, err := strconv.ParseInt(num, 0, 32)
+	if err != nil {
+		return uintptr(^fd), os.ErrInvalid
+	}
+
+	return uintptr(fd), nil
+}


### PR DESCRIPTION
There is a “bug” in the code, where Window’s `os.NewFile` argument is a `FileHandle` index, not a POSIX file descriptor. How does this bug manifest? The StandardInput for Windows is on FileHandle `-10`, instead of `0`. But trying to use a negative file descriptor value, will break the existing implementation.

But for POSIX we need to still only accept an unsigned int, thus the split of the `resolveFileHandle` between the two conditional build files.