### PR TITLE
Low hanging refactors

### DIFF
--- a/lib/files/create.go
+++ b/lib/files/create.go
@@ -7,12 +7,13 @@ import (
 	"path/filepath"
 )
 
-// Create creates a new file at the given filename, and
-// returns a files.Writer, which can be used to write contents to that filename.
+// Create returns a files.Writer, which can be used to write content to the resource at the given URL.
+//
+// If the given URL is a local filename, the file will be created, and truncated before this function returns.
 //
 // All errors and reversion functions returned by Option arguments are discarded.
-func Create(ctx context.Context, filename string, options ...Option) (Writer, error) {
-	f, err := create(ctx, filename)
+func Create(ctx context.Context, url string, options ...Option) (Writer, error) {
+	f, err := create(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -24,19 +25,19 @@ func Create(ctx context.Context, filename string, options ...Option) (Writer, er
 	return f, nil
 }
 
-func create(ctx context.Context, filename string) (Writer, error) {
-	switch filename {
+func create(ctx context.Context, resource string) (Writer, error) {
+	switch resource {
 	case "", "-", "/dev/stdout":
 		return os.Stdout, nil
 	case "/dev/stderr":
 		return os.Stderr, nil
 	}
 
-	if filepath.IsAbs(filename) {
-		return os.Create(filename)
+	if filepath.IsAbs(resource) {
+		return os.Create(resource)
 	}
 
-	if uri, err := url.Parse(filename); err == nil {
+	if uri, err := url.Parse(resource); err == nil {
 		uri = resolveFilename(ctx, uri)
 
 		if fs, ok := getFS(uri); ok {
@@ -44,5 +45,5 @@ func create(ctx context.Context, filename string) (Writer, error) {
 		}
 	}
 
-	return os.Create(filename)
+	return os.Create(resource)
 }

--- a/lib/files/create.go
+++ b/lib/files/create.go
@@ -7,9 +7,10 @@ import (
 	"path/filepath"
 )
 
-// Create takes a context and a filename (which may be a URL) and returns a
-// files.Writer that allows writing data to that local filename or URL. All
-// errors and reversion functions returned by Option arguments are discarded.
+// Create creates a new file at the given filename, and
+// returns a files.Writer, which can be used to write contents to that filename.
+//
+// All errors and reversion functions returned by Option arguments are discarded.
 func Create(ctx context.Context, filename string, options ...Option) (Writer, error) {
 	f, err := create(ctx, filename)
 	if err != nil {

--- a/lib/files/errors.go
+++ b/lib/files/errors.go
@@ -24,7 +24,7 @@ var (
 	// ErrNotSupported should be returned, if a particular feature or option is not supported.
 	ErrNotSupported = errors.New("not supported")
 
-	// ErrNotDirectory should be returned, if a request is made to ReadDir a non-directory.
+	// ErrNotDirectory should be returned, if a request is made to ReadDir with a non-directory.
 	ErrNotDirectory = syscall.ENOTDIR
 )
 

--- a/lib/files/errors.go
+++ b/lib/files/errors.go
@@ -27,3 +27,47 @@ var (
 	// ErrNotDirectory should be returned, if a request is made to ReadDir a non-directory.
 	ErrNotDirectory = syscall.ENOTDIR
 )
+
+type invalidURLError struct {
+	s string
+}
+
+func (e *invalidURLError) Error() string {
+	return e.s
+}
+
+func (e *invalidURLError) Unwrap() error {
+	if e == ErrURLInvalid {
+		return os.ErrInvalid
+	}
+
+	return ErrURLInvalid
+}
+
+func (e *invalidURLError) Is(target error) bool {
+	switch target {
+	case ErrURLInvalid, os.ErrInvalid:
+		return true
+	}
+
+	return e == target
+}
+
+// NewInvalidURLError returns an error that formats as the given text,
+// and where errors.Is will return true for both: files.ErrURLInvalid and os.ErrInvalid.
+func NewInvalidURLError(reason string) error {
+	return &invalidURLError{
+		s: reason,
+	}
+}
+
+// A set of Invalid URL Error to better identify and relate specific invalid URL details.
+var (
+	ErrURLInvalid = NewInvalidURLError("invalid url")
+
+	ErrURLCannotHaveAuthority = NewInvalidURLError("invalid url: scheme cannot have an authority")
+	ErrURLCannotHaveHost      = NewInvalidURLError("invalid url: scheme cannot have a host in authority")
+
+	ErrURLHostRequired = NewInvalidURLError("invalid url: scheme requires non-empty host in authority")
+	ErrURLPathRequired = NewInvalidURLError("invalid url: scheme requires non-empty path")
+)

--- a/lib/files/errors.go
+++ b/lib/files/errors.go
@@ -1,13 +1,17 @@
 package files
 
 import (
+	"errors"
 	"os"
+	"syscall"
 )
 
-// PathError returns an *os.PathError with appropriate fields set. DO NOT USE.
+// PathError is DEPRECATED, and returns an *os.PathError with appropriate fields set. DO NOT USE.
 //
 // This is a stop-gap quick-replace to remove `&os.PathError{ op, path, err }`.
 // One should use the direct complex literal instruction instead.
+//
+// Deprecated: use &os.PathError{} directly.
 func PathError(op, path string, err error) error {
 	return &os.PathError{
 		Op:   op,
@@ -15,3 +19,11 @@ func PathError(op, path string, err error) error {
 		Err:  err,
 	}
 }
+
+var (
+	// ErrNotSupported should be returned, if a particular feature or option is not supported.
+	ErrNotSupported = errors.New("not supported")
+
+	// ErrNotDirectory should be returned, if a request is made to ReadDir a non-directory.
+	ErrNotDirectory = syscall.ENOTDIR
+)

--- a/lib/files/errors_test.go
+++ b/lib/files/errors_test.go
@@ -1,0 +1,31 @@
+package files
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestInvalidURLErrors(t *testing.T) {
+	err := &invalidURLError{}
+
+	if !errors.Is(err, os.ErrInvalid) {
+		t.Error("errors.Is(invalidURLError, os.ErrInvalid) was false, wanted true")
+	}
+	if !errors.Is(err, ErrURLInvalid) {
+		t.Error("errors.Is(invalidURLError, ErrURLInvalid) was false, wanted true")
+	}
+	if !errors.Is(err, err) {
+		t.Errorf("errors.Is(invalidURLError, invalidURLError) was false, wanted true")
+	}
+
+	err2 := errors.Unwrap(err)
+	if err2 != ErrURLInvalid {
+		t.Errorf("errors.Unwrap(invalidURLError) was %#v, expected %#v", err2, ErrURLInvalid)
+	}
+
+	err3 := errors.Unwrap(err2)
+	if err3 != os.ErrInvalid {
+		t.Errorf("errors.Unwrap(ErrURLInvalid) was %#v, expected %#v", err3, os.ErrInvalid)
+	}
+}

--- a/lib/files/open.go
+++ b/lib/files/open.go
@@ -3,9 +3,7 @@ package files
 import (
 	"context"
 	"io/ioutil"
-	"net/url"
 	"os"
-	"path/filepath"
 )
 
 // Open opens the file at the given filename, and
@@ -31,46 +29,40 @@ func open(ctx context.Context, filename string) (Reader, error) {
 		return os.Stdin, nil
 	}
 
-	if filepath.IsAbs(filename) {
+	uri := parsePath(ctx, filename)
+	if isPath(uri) {
 		return os.Open(filename)
 	}
 
-	if uri, err := url.Parse(filename); err == nil {
-		uri = resolveFilename(ctx, uri)
-
-		if fs, ok := getFS(uri); ok {
-			return fs.Open(ctx, uri)
-		}
+	if fs, ok := getFS(uri); ok {
+		return fs.Open(ctx, uri)
 	}
 
-	return os.Open(filename)
+	return nil, ErrNotSupported
 }
 
-// ReadDir reads the directory at the given filename, and returns a slice of os.FileInfo,
-// which describes all of the files contained in the directory.
+// ReadDir reads the directory at the given filename, and
+// returns a slice of os.FileInfo, which describe the files contained in the directory.
 func ReadDir(ctx context.Context, filename string) ([]os.FileInfo, error) {
 	switch filename {
 	case "", "-", "/dev/stdin":
 		return os.Stdin.Readdir(0)
 	}
 
-	if filepath.IsAbs(filename) {
+	uri := parsePath(ctx, filename)
+	if isPath(uri) {
 		return ioutil.ReadDir(filename)
 	}
 
-	if uri, err := url.Parse(filename); err == nil {
-		uri = resolveFilename(ctx, uri)
-
-		if fs, ok := getFS(uri); ok {
-			return fs.List(ctx, uri)
-		}
+	if fs, ok := getFS(uri); ok {
+		return fs.List(ctx, uri)
 	}
 
-	return ioutil.ReadDir(filename)
+	return nil, ErrNotSupported
 }
 
-// List reads the directory at the given filename, and returns a slice of os.FileInfo,
-// which describes all of the files contained in the directory.
+// List reads the directory at the given filename, and
+// returns a slice of os.FileInfo, which describe the files contained in the directory.
 //
 // Depcrecated: Use `ReadDir`.
 func List(ctx context.Context, filename string) ([]os.FileInfo, error) {

--- a/lib/files/open.go
+++ b/lib/files/open.go
@@ -8,9 +8,10 @@ import (
 	"path/filepath"
 )
 
-// Open takes a Context and a filename (which may be a URL) and returns a
-// files.Reader which will read the contents of that filename or URL. All
-// errors and reversion functions returned by Option arguments are discarded.
+// Open opens the file at the given filename, and
+// returns a files.Reader, which will read the contents of that filename.
+//
+// All errors and reversion functions returned by Option arguments are discarded.
 func Open(ctx context.Context, filename string, options ...Option) (Reader, error) {
 	f, err := open(ctx, filename)
 	if err != nil {
@@ -45,9 +46,9 @@ func open(ctx context.Context, filename string) (Reader, error) {
 	return os.Open(filename)
 }
 
-// List takes a Context and a filename (which may be a URL) and returns a list
-// of os.FileInfo that describes the files contained in the directory or listing.
-func List(ctx context.Context, filename string) ([]os.FileInfo, error) {
+// ReadDir reads the directory at the given filename, and returns a slice of os.FileInfo,
+// which describes all of the files contained in the directory.
+func ReadDir(ctx context.Context, filename string) ([]os.FileInfo, error) {
 	switch filename {
 	case "", "-", "/dev/stdin":
 		return os.Stdin.Readdir(0)
@@ -66,4 +67,12 @@ func List(ctx context.Context, filename string) ([]os.FileInfo, error) {
 	}
 
 	return ioutil.ReadDir(filename)
+}
+
+// List reads the directory at the given filename, and returns a slice of os.FileInfo,
+// which describes all of the files contained in the directory.
+//
+// Depcrecated: Use `ReadDir`.
+func List(ctx context.Context, filename string) ([]os.FileInfo, error) {
+	return ReadDir(ctx, filename)
 }

--- a/lib/files/open.go
+++ b/lib/files/open.go
@@ -8,12 +8,11 @@ import (
 	"path/filepath"
 )
 
-// Open opens the file at the given filename, and
-// returns a files.Reader, which will read the contents of that filename.
+// Open returns a files.Reader, which can be used to read content from the resource at the given URL.
 //
 // All errors and reversion functions returned by Option arguments are discarded.
-func Open(ctx context.Context, filename string, options ...Option) (Reader, error) {
-	f, err := open(ctx, filename)
+func Open(ctx context.Context, url string, options ...Option) (Reader, error) {
+	f, err := open(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -25,17 +24,17 @@ func Open(ctx context.Context, filename string, options ...Option) (Reader, erro
 	return f, nil
 }
 
-func open(ctx context.Context, filename string) (Reader, error) {
-	switch filename {
+func open(ctx context.Context, resource string) (Reader, error) {
+	switch resource {
 	case "", "-", "/dev/stdin":
 		return os.Stdin, nil
 	}
 
-	if filepath.IsAbs(filename) {
-		return os.Open(filename)
+	if filepath.IsAbs(resource) {
+		return os.Open(resource)
 	}
 
-	if uri, err := url.Parse(filename); err == nil {
+	if uri, err := url.Parse(resource); err == nil {
 		uri = resolveFilename(ctx, uri)
 
 		if fs, ok := getFS(uri); ok {
@@ -43,22 +42,26 @@ func open(ctx context.Context, filename string) (Reader, error) {
 		}
 	}
 
-	return os.Open(filename)
+	return os.Open(resource)
 }
 
-// ReadDir reads the directory at the given filename, and
+// ReadDir reads the directory or listing of the resource at the given URL, and
 // returns a slice of os.FileInfo, which describe the files contained in the directory.
-func ReadDir(ctx context.Context, filename string) ([]os.FileInfo, error) {
-	switch filename {
+func ReadDir(ctx context.Context, url string) ([]os.FileInfo, error) {
+	return readDir(ctx, url)
+}
+
+func readDir(ctx context.Context, resource string) ([]os.FileInfo, error) {
+	switch resource {
 	case "", "-", "/dev/stdin":
 		return os.Stdin.Readdir(0)
 	}
 
-	if filepath.IsAbs(filename) {
-		return ioutil.ReadDir(filename)
+	if filepath.IsAbs(resource) {
+		return ioutil.ReadDir(resource)
 	}
 
-	if uri, err := url.Parse(filename); err == nil {
+	if uri, err := url.Parse(resource); err == nil {
 		uri = resolveFilename(ctx, uri)
 
 		if fs, ok := getFS(uri); ok {
@@ -66,13 +69,13 @@ func ReadDir(ctx context.Context, filename string) ([]os.FileInfo, error) {
 		}
 	}
 
-	return ioutil.ReadDir(filename)
+	return ioutil.ReadDir(resource)
 }
 
-// List reads the directory at the given filename, and
+// List reads the directory or listing of the resource at the given URL, and
 // returns a slice of os.FileInfo, which describe the files contained in the directory.
 //
 // Depcrecated: Use `ReadDir`.
-func List(ctx context.Context, filename string) ([]os.FileInfo, error) {
-	return ReadDir(ctx, filename)
+func List(ctx context.Context, url string) ([]os.FileInfo, error) {
+	return readDir(ctx, url)
 }

--- a/lib/files/option.go
+++ b/lib/files/option.go
@@ -1,14 +1,9 @@
 package files
 
 import (
-	"errors"
 	"os"
 	"time"
 )
-
-// ErrNotSupported should be returned when a specific file.File given to an
-// Option does not support the Option specified.
-var ErrNotSupported = errors.New("option not supported")
 
 // Option is a function that applies a specific option to a files.File, it
 // returns an Option and and error. If error is not nil, then the Option

--- a/lib/files/read.go
+++ b/lib/files/read.go
@@ -36,9 +36,9 @@ func Discard(r io.Reader) error {
 	return err
 }
 
-// Read reads the entire content of the file at the given filename into a byte-slice which it returns.
-func Read(ctx context.Context, filename string) ([]byte, error) {
-	f, err := Open(ctx, filename)
+// Read reads the entire content of the resource at the given URL into a byte-slice.
+func Read(ctx context.Context, url string) ([]byte, error) {
+	f, err := Open(ctx, url)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/files/read.go
+++ b/lib/files/read.go
@@ -6,28 +6,37 @@ import (
 	"io/ioutil"
 )
 
-// ReadFrom reads the entire content of an io.ReadCloser and returns the content as a byte slice. It will also Close the reader.
-func ReadFrom(r io.ReadCloser) ([]byte, error) {
+// ReadFrom reads the entire content of an io.Reader and returns the content as a byte slice.
+// If the Reader also implements io.Closer, it will also Close it.
+func ReadFrom(r io.Reader) ([]byte, error) {
 	b, err := ioutil.ReadAll(r)
-	if err1 := r.Close(); err == nil {
-		err = err1
+
+	if c, ok := r.(io.Closer); ok {
+		if err2 := c.Close(); err == nil {
+			err = err2
+		}
 	}
+
 	return b, err
 }
 
-// Discard throws away the entire content of an io.ReadCloser and closes the reader.
+// Discard throws away the entire content of an io.Reader.
+// If the Reader also implements io.Closer, it will also Close it.
+//
 // This is specifically not context aware, it is intended to always run to completion.
-func Discard(r io.ReadCloser) error {
+func Discard(r io.Reader) error {
 	_, err := io.Copy(ioutil.Discard, r)
 
-	if err2 := r.Close(); err == nil {
-		err = err2
+	if c, ok := r.(io.Closer); ok {
+		if err2 := c.Close(); err == nil {
+			err = err2
+		}
 	}
 
 	return err
 }
 
-// Read takes a Context and a filename and reads the entire content into a byte-slice which it returns.
+// Read reads the entire content of the file at the given filename into a byte-slice which it returns.
 func Read(ctx context.Context, filename string) ([]byte, error) {
 	f, err := Open(ctx, filename)
 	if err != nil {

--- a/lib/files/write.go
+++ b/lib/files/write.go
@@ -23,9 +23,9 @@ func WriteTo(w io.Writer, data []byte) error {
 	return err
 }
 
-// Write writes the entire content of data to the file at the given filename.
-func Write(ctx context.Context, filename string, data []byte) error {
-	f, err := Create(ctx, filename)
+// Write writes the entire content of data to the resource at the given URL.
+func Write(ctx context.Context, url string, data []byte) error {
+	f, err := Create(ctx, url)
 	if err != nil {
 		return err
 	}

--- a/lib/files/write.go
+++ b/lib/files/write.go
@@ -5,19 +5,25 @@ import (
 	"io"
 )
 
-// WriteTo will write the given data to the io.WriteCloser and Close the writer.
-func WriteTo(w io.WriteCloser, data []byte) error {
+// WriteTo writes the entire content of data to an io.Writer.
+// If the Writer also implements io.Closer, it will also Close it.
+func WriteTo(w io.Writer, data []byte) error {
 	n, err := w.Write(data)
+
 	if err == nil && n < len(data) {
 		err = io.ErrShortWrite
 	}
-	if err1 := w.Close(); err == nil {
-		err = err1
+
+	if c, ok := w.(io.Closer); ok {
+		if err2 := c.Close(); err == nil {
+			err = err2
+		}
 	}
+
 	return err
 }
 
-// Write will Create the given filename with the Context, and write the given data to it.
+// Write writes the entire content of data to the file at the given filename.
 func Write(ctx context.Context, filename string, data []byte) error {
 	f, err := Create(ctx, filename)
 	if err != nil {


### PR DESCRIPTION
Lots of documentation changes.

Widen the interfaces accepted by `files.ReadFrom` and `files.WriteTo`. Existing use will still have the same semantics/behavior.

Lay the foundation for better invalid URL error handling. So that we can return richer information about why a given URL was bad, other than just the os-level `"invalid argument"`.