### PR TITLE
Refactor: about scheme

### DIFF
--- a/lib/files/about/about.go
+++ b/lib/files/about/about.go
@@ -93,10 +93,10 @@ func init() {
 type handler struct{}
 
 func init() {
-	files.RegisterScheme(&handler{}, "about")
+	files.RegisterScheme(handler{}, "about")
 }
 
-func (h *handler) Create(ctx context.Context, uri *url.URL) (files.Writer, error) {
+func (h handler) Create(ctx context.Context, uri *url.URL) (files.Writer, error) {
 	return nil, &os.PathError{
 		Op:   "create",
 		Path: uri.String(),
@@ -104,7 +104,7 @@ func (h *handler) Create(ctx context.Context, uri *url.URL) (files.Writer, error
 	}
 }
 
-func (h *handler) Open(ctx context.Context, uri *url.URL) (files.Reader, error) {
+func (h handler) Open(ctx context.Context, uri *url.URL) (files.Reader, error) {
 	if uri.Host != "" || uri.User != nil {
 		return nil, &os.PathError{
 			Op:   "open",
@@ -147,11 +147,11 @@ func (h *handler) Open(ctx context.Context, uri *url.URL) (files.Reader, error) 
 	return wrapper.NewReaderFromBytes(data, uri, time.Now()), nil
 }
 
-func (h *handler) List(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
+func (h handler) List(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
 	return h.ReadDir(ctx, uri)
 }
 
-func (h *handler) ReadDir(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
+func (h handler) ReadDir(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
 	if uri.Host != "" || uri.User != nil {
 		return nil, &os.PathError{
 			Op:   "readdir",

--- a/lib/files/about/about.go
+++ b/lib/files/about/about.go
@@ -2,20 +2,93 @@
 package aboutfiles
 
 import (
-	"bytes"
 	"context"
-	"errors"
-	"fmt"
 	"net/url"
 	"os"
-	"syscall"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/puellanivis/breton/lib/files"
 	"github.com/puellanivis/breton/lib/files/wrapper"
-	"github.com/puellanivis/breton/lib/os/process"
-	"github.com/puellanivis/breton/lib/sort"
 )
+
+type reader interface {
+	ReadAll() ([]byte, error)
+}
+
+type lister interface {
+	ReadDir() ([]os.FileInfo, error)
+}
+
+type aboutMap map[string]reader
+
+func (m aboutMap) keys() []string {
+	var keys []string
+
+	for key := range m {
+		if key == "" || strings.HasPrefix(key, ".") {
+			continue
+		}
+
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+func (m aboutMap) ReadAll() ([]byte, error) {
+	var lines []string
+
+	for _, key := range m.keys() {
+		uri := &url.URL{
+			Scheme: "about",
+			Opaque: url.PathEscape(key),
+		}
+
+		lines = append(lines, uri.String())
+	}
+
+	return []byte(strings.Join(append(lines, ""), "\n")), nil
+}
+
+func (m aboutMap) ReadDir() ([]os.FileInfo, error) {
+	var infos []os.FileInfo
+
+	for _, key := range m.keys() {
+		uri := &url.URL{
+			Scheme: "about",
+			Opaque: url.PathEscape(key),
+		}
+
+		infos = append(infos, wrapper.NewInfo(uri, 0, time.Now()))
+	}
+
+	return infos, nil
+}
+
+var (
+	about = aboutMap{
+		"":              version,
+		"blank":         blank,
+		"cache":         blank,
+		"invalid":       errorURL{os.ErrNotExist},
+		"html-kind":     errorURL{ErrNoSuchHost},
+		"legacy-compat": errorURL{ErrNoSuchHost},
+		"now":           now,
+		"plugins":       schemeList{},
+		"srcdoc":        errorURL{ErrNoSuchHost},
+		"version":       version,
+	}
+)
+
+func init() {
+	// if aboutMap references about, then about references aboutMap
+	// and go errors with "initialization loop"
+	about["about"] = about
+}
 
 type handler struct{}
 
@@ -24,153 +97,112 @@ func init() {
 }
 
 func (h *handler) Create(ctx context.Context, uri *url.URL) (files.Writer, error) {
-	return nil, files.PathError("create", uri.String(), os.ErrInvalid)
-}
-
-type fn func() ([]byte, error)
-
-func blank() ([]byte, error) {
-	return nil, nil
-}
-
-func notfound() ([]byte, error) {
-	return nil, os.ErrNotExist
-}
-
-var errUnresolvable = errors.New("unresolvable address")
-
-func unresolvable() ([]byte, error) {
-	return nil, errUnresolvable
-}
-
-func version() ([]byte, error) {
-	return append([]byte(process.Version()), '\n'), nil
-}
-
-var (
-	aboutMap = map[string]fn{
-		"":              version,
-		"blank":         blank,
-		"cache":         blank,
-		"invalid":       notfound,
-		"html-kind":     unresolvable,
-		"legacy-compat": unresolvable,
-		"plugins":       plugins,
-		"srcdoc":        unresolvable,
-		"version":       version,
+	return nil, &os.PathError{
+		Op:   "create",
+		Path: uri.String(),
+		Err:  files.ErrNotSupported,
 	}
-)
-
-func init() {
-	// if aboutMap references about, then about references aboutMap
-	// and go errors with "initialization loop"
-	aboutMap["about"] = about
-}
-
-func listOf(list []string) ([]byte, error) {
-	sort.Strings(list)
-
-	b := new(bytes.Buffer)
-
-	for _, item := range list {
-		fmt.Fprintln(b, item)
-	}
-
-	return b.Bytes(), nil
-}
-
-func plugins() ([]byte, error) {
-	return listOf(files.RegisteredSchemes())
-}
-
-func about() ([]byte, error) {
-	var list []string
-
-	for name := range aboutMap {
-		uri := &url.URL{
-			Scheme: "about",
-			Opaque: name,
-		}
-
-		list = append(list, uri.String())
-	}
-
-	return listOf(list)
 }
 
 func (h *handler) Open(ctx context.Context, uri *url.URL) (files.Reader, error) {
 	if uri.Host != "" || uri.User != nil {
-		return nil, files.PathError("open", uri.String(), os.ErrInvalid)
+		return nil, &os.PathError{
+			Op:   "open",
+			Path: uri.String(),
+			Err:  files.ErrURLCannotHaveAuthority,
+		}
 	}
 
 	path := uri.Path
 	if path == "" {
-		path = uri.Opaque
+		var err error
+		path, err = url.PathUnescape(uri.Opaque)
+		if err != nil {
+			return nil, &os.PathError{
+				Op:   "open",
+				Path: uri.String(),
+				Err:  files.ErrURLInvalid,
+			}
+		}
 	}
 
-	f, ok := aboutMap[path]
+	f, ok := about[path]
 	if !ok {
-		return nil, files.PathError("open", uri.String(), os.ErrNotExist)
+		return nil, &os.PathError{
+			Op:   "open",
+			Path: uri.String(),
+			Err:  os.ErrNotExist,
+		}
 	}
 
-	data, err := f()
+	data, err := f.ReadAll()
 	if err != nil {
-		return nil, files.PathError("open", uri.String(), err)
+		return nil, &os.PathError{
+			Op:   "open",
+			Path: uri.String(),
+			Err:  err,
+		}
 	}
 
 	return wrapper.NewReaderFromBytes(data, uri, time.Now()), nil
 }
 
 func (h *handler) List(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
+	return h.ReadDir(ctx, uri)
+}
+
+func (h *handler) ReadDir(ctx context.Context, uri *url.URL) ([]os.FileInfo, error) {
 	if uri.Host != "" || uri.User != nil {
-		return nil, files.PathError("readdir", uri.String(), os.ErrInvalid)
+		return nil, &os.PathError{
+			Op:   "readdir",
+			Path: uri.String(),
+			Err:  files.ErrURLCannotHaveAuthority,
+		}
 	}
 
 	path := uri.Path
 	if path == "" {
-		path = uri.Opaque
-	}
-
-	if f, ok := aboutMap[path]; !ok {
-		return nil, files.PathError("readdir", uri.String(), os.ErrNotExist)
-
-	} else if f != nil {
-		if _, err := f(); err != nil {
-			return nil, files.PathError("readdir", uri.String(), err)
-		}
-	}
-
-	if path != "about" && path != "" {
-		return nil, files.PathError("readdir", uri.String(), syscall.ENOTDIR)
-	}
-
-	var list []string
-	for name := range aboutMap {
-		list = append(list, name)
-	}
-	sort.Strings(list)
-
-	var ret []os.FileInfo
-
-	for _, name := range list {
-		f := aboutMap[name]
-
-		uri := &url.URL{
-			Scheme: "about",
-			Opaque: name,
-		}
-
-		if f == nil {
-			continue
-		}
-
-		data, err := f()
+		var err error
+		path, err = url.PathUnescape(uri.Opaque)
 		if err != nil {
-			continue
+			return nil, &os.PathError{
+				Op:   "readdir",
+				Path: uri.String(),
+				Err:  files.ErrURLInvalid,
+			}
 		}
-
-		ret = append(ret, wrapper.NewInfo(uri, len(data), time.Now()))
 	}
 
-	return ret, nil
+	if path == "" {
+		path = "about"
+	}
+
+	f, ok := about[path]
+	if !ok {
+		return nil, &os.PathError{
+			Op:   "readdir",
+			Path: uri.String(),
+			Err:  os.ErrNotExist,
+		}
+	}
+
+	l, ok := f.(lister)
+	if !ok {
+		return nil, &os.PathError{
+			Op:   "readdir",
+			Path: uri.String(),
+			Err:  files.ErrNotDirectory,
+		}
+	}
+
+	infos, err := l.ReadDir()
+	if err != nil {
+		return nil, &os.PathError{
+			Op:   "readdir",
+			Path: uri.String(),
+			Err:  err,
+		}
+	}
+
+	return infos, nil
 }

--- a/lib/files/about/about.go
+++ b/lib/files/about/about.go
@@ -85,8 +85,8 @@ var (
 )
 
 func init() {
-	// if aboutMap references about, then about references aboutMap
-	// and go errors with "initialization loop"
+	// During initialization about is not allowed to reference about,
+	// else Go errors with "initialization loop".
 	about["about"] = about
 }
 

--- a/lib/files/about/errors.go
+++ b/lib/files/about/errors.go
@@ -1,0 +1,25 @@
+package aboutfiles
+
+import (
+	"errors"
+	"os"
+)
+
+type errorURL struct {
+	error
+}
+
+func (e errorURL) ReadAll() ([]byte, error) {
+	return nil, e.error
+}
+
+func (e errorURL) ReadDir() ([]os.FileInfo, error) {
+	return nil, e.error
+}
+
+func (e errorURL) Unwrap() error {
+	return e.error
+}
+
+// ErrNoSuchHost defines an error, where a DNS host lookup failed to resolve.
+var ErrNoSuchHost = errors.New("no such host")

--- a/lib/files/about/schemes.go
+++ b/lib/files/about/schemes.go
@@ -1,0 +1,45 @@
+package aboutfiles
+
+import (
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/puellanivis/breton/lib/files"
+	"github.com/puellanivis/breton/lib/files/wrapper"
+)
+
+type schemeList struct{}
+
+func (schemeList) ReadAll() ([]byte, error) {
+	schemes := files.RegisteredSchemes()
+
+	var lines []string
+
+	for _, scheme := range schemes {
+		uri := &url.URL{
+			Scheme: scheme,
+		}
+
+		lines = append(lines, uri.String())
+	}
+
+	return []byte(strings.Join(append(lines, ""), "\n")), nil
+}
+
+func (schemeList) ReadDir() ([]os.FileInfo, error) {
+	schemes := files.RegisteredSchemes()
+
+	var infos []os.FileInfo
+
+	for _, scheme := range schemes {
+		uri := &url.URL{
+			Scheme: scheme,
+		}
+
+		infos = append(infos, wrapper.NewInfo(uri, 0, time.Now()))
+	}
+
+	return infos, nil
+}

--- a/lib/files/about/strings.go
+++ b/lib/files/about/strings.go
@@ -1,0 +1,19 @@
+package aboutfiles
+
+import (
+	"time"
+
+	"github.com/puellanivis/breton/lib/os/process"
+)
+
+type stringFunc func() string
+
+func (f stringFunc) ReadAll() ([]byte, error) {
+	return append([]byte(f()), '\n'), nil
+}
+
+var (
+	blank   stringFunc = func() string { return "" }
+	version stringFunc = func() string { return process.Version() }
+	now     stringFunc = func() string { return time.Now().Truncate(0).String() }
+)


### PR DESCRIPTION
The `about:` scheme can definitely do with a refactor. Instead of everything just an unclear `func() ([]byte, error)`, make each one a implement a common interface, that covers the base case: `ReadAll() ([]byte, error)`. Then, for ones that support listing as a directory, implement also an extension interface for `ReadDir() ([]os.FileInfo, error)`.

This requires reimplementing all of the sub-functions that act as files, and expanding those that also `ReadDir`.

Beyond that, break things out into different files to correlate code better.