### PR TITLE
Refactor about scheme: Missed commit

### DIFF
--- a/lib/files/about/about.go
+++ b/lib/files/about/about.go
@@ -90,11 +90,11 @@ func init() {
 	about["about"] = about
 }
 
-type handler struct{}
-
 func init() {
 	files.RegisterScheme(handler{}, "about")
 }
+
+type handler struct{}
 
 func (h handler) Create(ctx context.Context, uri *url.URL) (files.Writer, error) {
 	return nil, &os.PathError{


### PR DESCRIPTION
This commit was intended to go in with the previous merge for refactoring the `about` scheme, but was overlooked.