### PR TITLE
Normalize S3 errors based on status code

### DIFF
--- a/lib/files/s3files/reader.go
+++ b/lib/files/s3files/reader.go
@@ -30,7 +30,7 @@ func (h *handler) Open(ctx context.Context, uri *url.URL) (files.Reader, error) 
 
 	res, err := cl.GetObjectWithContext(ctx, req)
 	if err != nil {
-		return nil, files.PathError("read", uri.String(), err)
+		return nil, files.PathError("read", uri.String(), normalizeError(err))
 	}
 
 	var l int64

--- a/lib/files/s3files/s3.go
+++ b/lib/files/s3files/s3.go
@@ -168,14 +168,17 @@ func (h *handler) List(ctx context.Context, uri *url.URL) ([]os.FileInfo, error)
 func normalizeError(err error) error {
 	type StatusCoder interface{ StatusCode() int }
 
-	if sc, ok := err.(StatusCoder); ok {
-		switch sc.StatusCode() {
-		case http.StatusUnauthorized, http.StatusForbidden:
-			return os.ErrPermission
-		case http.StatusNotFound:
-			return os.ErrNotExist
-		}
+	sc, ok := err.(StatusCoder)
+	if !ok {
+		return err
 	}
 
-	return err
+	switch sc.StatusCode() {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return os.ErrPermission
+	case http.StatusNotFound:
+		return os.ErrNotExist
+	default:
+		return err
+	}
 }

--- a/lib/files/s3files/s3.go
+++ b/lib/files/s3files/s3.go
@@ -131,7 +131,6 @@ func (h *handler) List(ctx context.Context, uri *url.URL) ([]os.FileInfo, error)
 		Prefix:    aws.String(key),
 	}
 
-	type StatusCoder interface{ StatusCode() int }
 	res, err := cl.ListObjectsWithContext(ctx, req)
 	if err != nil {
 		return nil, files.PathError("list", uri.String(), normalizeError(err))

--- a/lib/files/s3files/writer.go
+++ b/lib/files/s3files/writer.go
@@ -32,7 +32,7 @@ func (h *handler) Create(ctx context.Context, uri *url.URL) (files.Writer, error
 
 		_, err = cl.PutObjectWithContext(ctx, req)
 		if err != nil {
-			return files.PathError("sync", uri.String(), err)
+			return files.PathError("sync", uri.String(), normalizeError(err))
 		}
 
 		return nil


### PR DESCRIPTION
S3 actions do not return normal `os.ErrPermission` or `os.ErrNotExist` errors, rather they return a complex error type `s3err` which is an internal package, and thus the type cannot be type asserted.

However, the type does embed `awserr.RequestFailure` which is an interface that implements `interface{ StatusCode() int }` at which point it uses the same codes as HTTP status. So, we borrow from the `httpfiles` implementation the `getErr(*http.Response)` except here, we use `normalizeError(error)`.

Now, we get:
```
allcat --list s3://bucket/key
E1201 14:39:08.420547   28297 allcat.go:76] files.List: list s3://bucket/key: permission denied
```